### PR TITLE
feat: Add uv-installable package structure with CLI entry points

### DIFF
--- a/eab/__main__.py
+++ b/eab/__main__.py
@@ -1,5 +1,6 @@
 """Allow running as: python -m eab"""
+import sys
 from .daemon import main
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/eab/control.py
+++ b/eab/control.py
@@ -1,0 +1,1846 @@
+#!/usr/bin/env python3
+"""
+eab-control: Agent-friendly CLI for Embedded Agent Bridge (EAB).
+
+This module provides a comprehensive command-line interface for managing
+the EAB daemon and interacting with embedded devices through serial connections.
+
+Design goals:
+- Tiny, stable surface area for LLM agents
+- Optional JSON output for reliable parsing
+- Works with the existing file-based IPC used by the EAB daemon
+
+Main commands:
+- status: Check daemon and device status
+- tail: View serial output logs
+- send: Send commands to the device
+- flash: Flash firmware to embedded devices
+- openocd: Manage OpenOCD for JTAG debugging
+- gdb: Run GDB commands through EAB
+
+Entry points:
+- eab-control: Main CLI entry point (installed via pip)
+- Can also be imported and called programmatically via main(argv)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import subprocess
+import base64
+import signal
+import shutil
+from dataclasses import asdict
+from typing import Any, Optional
+
+from eab.command_file import append_command
+from eab.capture import capture_between_markers
+from eab.singleton import check_singleton, kill_existing_daemon
+from eab.port_lock import list_all_locks, cleanup_dead_locks
+from eab.openocd_bridge import OpenOCDBridge, DEFAULT_TELNET_PORT, DEFAULT_GDB_PORT, DEFAULT_TCL_PORT
+from eab.gdb_bridge import run_gdb_batch
+from eab.chips import get_chip_profile
+
+
+DEFAULT_BASE_DIR = "/tmp/eab-session"
+
+
+def _now_iso() -> str:
+    # Keep it simple; agents mostly need consistent ordering.
+    return time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime())
+
+
+def _print(obj: Any, *, json_mode: bool) -> None:
+    if json_mode:
+        print(json.dumps(obj, indent=2, sort_keys=True))
+    else:
+        if isinstance(obj, str):
+            print(obj)
+        else:
+            print(json.dumps(obj, indent=2, sort_keys=True))
+
+
+def _resolve_base_dir(override: Optional[str]) -> str:
+    if override:
+        return override
+    existing = check_singleton()
+    if existing and existing.is_alive and existing.base_dir and existing.base_dir != "unknown":
+        return existing.base_dir
+    return DEFAULT_BASE_DIR
+
+
+def _read_text(path: str) -> str:
+    with open(path, "r", encoding="utf-8", errors="replace") as f:
+        return f.read()
+
+
+def _tail_lines(path: str, lines: int) -> list[str]:
+    try:
+        text = _read_text(path)
+    except FileNotFoundError:
+        return []
+    raw_lines = text.splitlines()
+    if lines <= 0:
+        return []
+    return raw_lines[-lines:]
+
+
+def _read_bytes(path: str, offset: int, length: int) -> bytes:
+    if length <= 0:
+        return b""
+    with open(path, "rb") as f:
+        f.seek(offset)
+        return f.read(length)
+
+
+def _parse_event_line(line: str) -> dict[str, Any]:
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        return {"raw": line, "error": "invalid_json"}
+
+
+def _tail_events(path: str, lines: int) -> list[dict[str, Any]]:
+    raw = _tail_lines(path, lines)
+    return [_parse_event_line(line) for line in raw]
+
+
+_TS_PREFIX = re.compile(r"^\[(\d{2}:\d{2}:\d{2}\.\d{3})\]\s+(.*)$")
+
+
+def _parse_log_line(line: str) -> dict[str, Any]:
+    m = _TS_PREFIX.match(line)
+    if not m:
+        return {"timestamp": None, "content": line, "raw": line}
+    return {"timestamp": m.group(1), "content": m.group(2), "raw": line}
+
+
+def _event_matches(
+    event: dict[str, Any],
+    *,
+    event_type: Optional[str],
+    contains: Optional[str],
+    command: Optional[str],
+) -> bool:
+    if event_type and event.get("type") != event_type:
+        return False
+    if command and event.get("data", {}).get("command") != command:
+        return False
+    if contains:
+        try:
+            blob = json.dumps(event, sort_keys=True)
+        except Exception:
+            blob = str(event)
+        if contains not in blob:
+            return False
+    return True
+
+
+def cmd_status(*, base_dir: str, json_mode: bool) -> int:
+    existing = check_singleton()
+    status_path = os.path.join(base_dir, "status.json")
+
+    status: Optional[dict[str, Any]]
+    try:
+        status = json.loads(_read_text(status_path))
+    except FileNotFoundError:
+        status = None
+    except json.JSONDecodeError:
+        status = {"error": "invalid_json", "path": status_path}
+
+    payload: dict[str, Any] = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "daemon": asdict(existing) if existing else {"running": False},
+        "paths": {
+            "base_dir": base_dir,
+            "status_json": status_path,
+            "latest_log": os.path.join(base_dir, "latest.log"),
+            "alerts_log": os.path.join(base_dir, "alerts.log"),
+            "events_log": os.path.join(base_dir, "events.jsonl"),
+            "data_bin": os.path.join(base_dir, "data.bin"),
+            "stream_json": os.path.join(base_dir, "stream.json"),
+            "cmd_txt": os.path.join(base_dir, "cmd.txt"),
+            "pause_txt": os.path.join(base_dir, "pause.txt"),
+        },
+        "status": status,
+    }
+
+    if json_mode:
+        _print(payload, json_mode=True)
+    else:
+        if existing and existing.is_alive:
+            print("EAB daemon: RUNNING")
+            print(f"  pid: {existing.pid}")
+            print(f"  port: {existing.port}")
+            print(f"  base_dir: {existing.base_dir}")
+            print(f"  started: {existing.started}")
+        else:
+            print("EAB daemon: NOT RUNNING")
+        if status is not None:
+            print("")
+            print("status.json:")
+            print(json.dumps(status, indent=2, sort_keys=True))
+
+    return 0 if (existing and existing.is_alive) else 1
+
+
+def cmd_tail(*, base_dir: str, lines: int, json_mode: bool) -> int:
+    log_path = os.path.join(base_dir, "latest.log")
+    raw = _tail_lines(log_path, lines)
+    if json_mode:
+        _print(
+            {
+                "schema_version": 1,
+                "timestamp": _now_iso(),
+                "path": log_path,
+                "lines": [_parse_log_line(l) for l in raw],
+            },
+            json_mode=True,
+        )
+    else:
+        for line in raw:
+            print(line)
+    return 0
+
+
+def cmd_alerts(*, base_dir: str, lines: int, json_mode: bool) -> int:
+    alerts_path = os.path.join(base_dir, "alerts.log")
+    raw = _tail_lines(alerts_path, lines)
+    if json_mode:
+        _print(
+            {
+                "schema_version": 1,
+                "timestamp": _now_iso(),
+                "path": alerts_path,
+                "lines": [_parse_log_line(l) for l in raw],
+            },
+            json_mode=True,
+        )
+    else:
+        for line in raw:
+            print(line)
+    return 0
+
+
+def cmd_events(*, base_dir: str, lines: int, json_mode: bool) -> int:
+    events_path = os.path.join(base_dir, "events.jsonl")
+    if json_mode:
+        _print(
+            {
+                "schema_version": 1,
+                "timestamp": _now_iso(),
+                "path": events_path,
+                "events": _tail_events(events_path, lines),
+            },
+            json_mode=True,
+        )
+    else:
+        for event in _tail_events(events_path, lines):
+            print(json.dumps(event, sort_keys=True))
+    return 0
+
+
+def _await_log_ack(log_path: str, marker: str, timeout_s: float) -> bool:
+    start = time.time()
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+            f.seek(0, os.SEEK_END)
+            pos = f.tell()
+            while time.time() - start < timeout_s:
+                f.seek(pos)
+                chunk = f.read()
+                if chunk:
+                    for line in chunk.splitlines():
+                        if marker in line:
+                            return True
+                    pos = f.tell()
+                time.sleep(0.05)
+    except FileNotFoundError:
+        return False
+    return False
+
+
+def _await_event(
+    events_path: str,
+    *,
+    event_type: Optional[str],
+    contains: Optional[str],
+    command: Optional[str],
+    timeout_s: float,
+) -> Optional[dict[str, Any]]:
+    start = time.time()
+    try:
+        with open(events_path, "r", encoding="utf-8", errors="replace") as f:
+            f.seek(0, os.SEEK_END)
+            pos = f.tell()
+            while time.time() - start < timeout_s:
+                f.seek(pos)
+                chunk = f.read()
+                if chunk:
+                    for line in chunk.splitlines():
+                        event = _parse_event_line(line)
+                        if _event_matches(
+                            event,
+                            event_type=event_type,
+                            contains=contains,
+                            command=command,
+                        ):
+                            return event
+                    pos = f.tell()
+                time.sleep(0.05)
+    except FileNotFoundError:
+        return None
+    return None
+
+
+def cmd_send(
+    *,
+    base_dir: str,
+    text: str,
+    await_ack: bool,
+    await_event: bool,
+    timeout_s: float,
+    json_mode: bool,
+) -> int:
+    cmd_path = os.path.join(base_dir, "cmd.txt")
+    log_path = os.path.join(base_dir, "latest.log")
+    events_path = os.path.join(base_dir, "events.jsonl")
+
+    started = time.time()
+    append_command(cmd_path, text)
+
+    acknowledged = False
+    ack_source: Optional[str] = None
+    ack_event: Optional[dict[str, Any]] = None
+
+    if await_event:
+        ack_event = _await_event(
+            events_path,
+            event_type="command_sent",
+            contains=None,
+            command=text,
+            timeout_s=timeout_s,
+        )
+        acknowledged = ack_event is not None
+        ack_source = "event"
+
+    if await_ack and not acknowledged:
+        marker = f">>> CMD: {text}"
+        acknowledged = _await_log_ack(log_path, marker, timeout_s=timeout_s)
+        ack_source = "log"
+
+    duration_ms = int((time.time() - started) * 1000)
+
+    result = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "command": text,
+        "queued_to": cmd_path,
+        "acknowledged": acknowledged,
+        "ack_source": ack_source,
+        "ack_event": ack_event,
+        "duration_ms": duration_ms,
+    }
+
+    if json_mode:
+        _print(result, json_mode=True)
+    else:
+        print(f"sent: {text}")
+        if await_ack or await_event:
+            print("ack: ok" if acknowledged else "ack: timeout")
+
+    return 0 if (not await_ack and not await_event) or acknowledged else 1
+
+
+def cmd_wait(*, base_dir: str, pattern: str, timeout_s: float, json_mode: bool) -> int:
+    log_path = os.path.join(base_dir, "latest.log")
+    regex = re.compile(pattern)
+
+    started = time.time()
+
+    try:
+        with open(log_path, "r", encoding="utf-8", errors="replace") as f:
+            f.seek(0, os.SEEK_END)
+            pos = f.tell()
+
+            while time.time() - started < timeout_s:
+                f.seek(pos)
+                chunk = f.read()
+                if chunk:
+                    for line in chunk.splitlines():
+                        if regex.search(line):
+                            result = {
+                                "schema_version": 1,
+                                "timestamp": _now_iso(),
+                                "pattern": pattern,
+                                "matched": True,
+                                "line": _parse_log_line(line),
+                                "duration_ms": int((time.time() - started) * 1000),
+                            }
+                            _print(result, json_mode=json_mode)
+                            return 0
+                    pos = f.tell()
+                time.sleep(0.05)
+    except FileNotFoundError:
+        pass
+
+    result = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "pattern": pattern,
+        "matched": False,
+        "duration_ms": int((time.time() - started) * 1000),
+    }
+    _print(result, json_mode=json_mode)
+    return 1
+
+
+def cmd_wait_event(
+    *,
+    base_dir: str,
+    event_type: Optional[str],
+    contains: Optional[str],
+    command: Optional[str],
+    timeout_s: float,
+    json_mode: bool,
+) -> int:
+    events_path = os.path.join(base_dir, "events.jsonl")
+    started = time.time()
+
+    event = _await_event(
+        events_path,
+        event_type=event_type,
+        contains=contains,
+        command=command,
+        timeout_s=timeout_s,
+    )
+
+    result = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "event_type": event_type,
+        "contains": contains,
+        "command": command,
+        "matched": event is not None,
+        "event": event,
+        "duration_ms": int((time.time() - started) * 1000),
+    }
+    _print(result, json_mode=json_mode)
+    return 0 if event is not None else 1
+
+
+def cmd_pause(*, base_dir: str, seconds: int, json_mode: bool) -> int:
+    pause_path = os.path.join(base_dir, "pause.txt")
+    pause_until = time.time() + seconds
+    os.makedirs(base_dir, exist_ok=True)
+    with open(pause_path, "w", encoding="utf-8") as f:
+        f.write(str(pause_until))
+
+    payload = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "paused": True,
+        "pause_until": pause_until,
+        "pause_path": pause_path,
+    }
+    _print(payload, json_mode=json_mode)
+    return 0
+
+
+def cmd_resume(*, base_dir: str, json_mode: bool) -> int:
+    pause_path = os.path.join(base_dir, "pause.txt")
+    try:
+        os.remove(pause_path)
+    except FileNotFoundError:
+        pass
+
+    payload = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "paused": False,
+        "pause_path": pause_path,
+    }
+    _print(payload, json_mode=json_mode)
+    return 0
+
+
+def cmd_openocd_status(*, base_dir: str, json_mode: bool) -> int:
+    bridge = OpenOCDBridge(base_dir)
+    st = bridge.status()
+    _print(
+        {
+            "running": st.running,
+            "pid": st.pid,
+            "cfg_path": st.cfg_path,
+            "log_path": st.log_path,
+            "err_path": st.err_path,
+            "last_error": st.last_error,
+            "telnet_port": st.telnet_port,
+            "gdb_port": st.gdb_port,
+            "tcl_port": st.tcl_port,
+        },
+        json_mode=json_mode,
+    )
+    return 0
+
+
+def cmd_openocd_start(
+    *,
+    base_dir: str,
+    chip: str,
+    vid: str,
+    pid: str,
+    telnet_port: int,
+    gdb_port: int,
+    tcl_port: int,
+    json_mode: bool,
+) -> int:
+    bridge = OpenOCDBridge(base_dir)
+    st = bridge.start(
+        chip=chip,
+        vid=vid,
+        pid=pid,
+        telnet_port=telnet_port,
+        gdb_port=gdb_port,
+        tcl_port=tcl_port,
+    )
+    _print(
+        {
+            "running": st.running,
+            "pid": st.pid,
+            "cfg_path": st.cfg_path,
+            "log_path": st.log_path,
+            "err_path": st.err_path,
+            "last_error": st.last_error,
+            "telnet_port": st.telnet_port,
+            "gdb_port": st.gdb_port,
+            "tcl_port": st.tcl_port,
+        },
+        json_mode=json_mode,
+    )
+    return 0 if st.running else 1
+
+
+def cmd_openocd_stop(*, base_dir: str, json_mode: bool) -> int:
+    bridge = OpenOCDBridge(base_dir)
+    st = bridge.stop()
+    _print(
+        {
+            "running": st.running,
+            "pid": st.pid,
+        },
+        json_mode=json_mode,
+    )
+    return 0
+
+
+def cmd_openocd_cmd(
+    *,
+    base_dir: str,
+    command: str,
+    telnet_port: int,
+    timeout_s: float,
+    json_mode: bool,
+) -> int:
+    bridge = OpenOCDBridge(base_dir)
+    out = bridge.cmd(command, telnet_port=telnet_port, timeout_s=timeout_s)
+    _print({"command": command, "output": out}, json_mode=json_mode)
+    return 0
+
+
+def cmd_gdb(
+    *,
+    base_dir: str,
+    chip: str,
+    target: str,
+    elf: Optional[str],
+    gdb_path: Optional[str],
+    commands: list[str],
+    timeout_s: float,
+    json_mode: bool,
+) -> int:
+    # base_dir is currently unused; included for symmetry and future session logging.
+    res = run_gdb_batch(
+        chip=chip,
+        target=target,
+        elf=elf,
+        gdb_path=gdb_path,
+        commands=commands,
+        timeout_s=timeout_s,
+    )
+    _print(
+        {
+            "success": res.success,
+            "returncode": res.returncode,
+            "gdb_path": res.gdb_path,
+            "stdout": res.stdout,
+            "stderr": res.stderr,
+        },
+        json_mode=json_mode,
+    )
+    return 0 if res.success else 1
+
+
+def cmd_stream_start(
+    *,
+    base_dir: str,
+    mode: str,
+    chunk_size: int,
+    marker: Optional[str],
+    pattern_matching: bool,
+    truncate: bool,
+    json_mode: bool,
+) -> int:
+    stream_path = os.path.join(base_dir, "stream.json")
+    payload = {
+        "enabled": True,
+        "mode": mode,
+        "chunk_size": chunk_size,
+        "marker": marker,
+        "pattern_matching": pattern_matching,
+        "truncate": truncate,
+    }
+    os.makedirs(base_dir, exist_ok=True)
+    with open(stream_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+
+    result = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "stream_path": stream_path,
+        "config": payload,
+    }
+    _print(result, json_mode=json_mode)
+    return 0
+
+
+def cmd_stream_stop(*, base_dir: str, json_mode: bool) -> int:
+    stream_path = os.path.join(base_dir, "stream.json")
+    try:
+        os.remove(stream_path)
+    except FileNotFoundError:
+        pass
+
+    result = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "stream_path": stream_path,
+        "disabled": True,
+    }
+    _print(result, json_mode=json_mode)
+    return 0
+
+
+def cmd_recv(
+    *,
+    base_dir: str,
+    offset: int,
+    length: int,
+    output_path: Optional[str],
+    base64_output: bool,
+    json_mode: bool,
+) -> int:
+    data_path = os.path.join(base_dir, "data.bin")
+    try:
+        payload = _read_bytes(data_path, offset, length)
+    except FileNotFoundError:
+        result = {
+            "schema_version": 1,
+            "timestamp": _now_iso(),
+            "error": "missing_data",
+            "data_path": data_path,
+        }
+        _print(result, json_mode=json_mode)
+        return 1
+
+    if output_path:
+        with open(output_path, "wb") as f:
+            f.write(payload)
+        result = {
+            "schema_version": 1,
+            "timestamp": _now_iso(),
+            "data_path": data_path,
+            "offset": offset,
+            "length": len(payload),
+            "output_path": output_path,
+        }
+        _print(result, json_mode=json_mode)
+        return 0
+
+    result: dict[str, Any] = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "data_path": data_path,
+        "offset": offset,
+        "length": len(payload),
+    }
+    if base64_output:
+        result["data_base64"] = base64.b64encode(payload).decode("ascii")
+    _print(result, json_mode=json_mode)
+    return 0
+
+
+def cmd_recv_latest(
+    *,
+    base_dir: str,
+    length: int,
+    output_path: Optional[str],
+    base64_output: bool,
+    json_mode: bool,
+) -> int:
+    data_path = os.path.join(base_dir, "data.bin")
+    try:
+        size = os.path.getsize(data_path)
+    except FileNotFoundError:
+        size = 0
+    offset = max(0, size - length)
+    return cmd_recv(
+        base_dir=base_dir,
+        offset=offset,
+        length=length,
+        output_path=output_path,
+        base64_output=base64_output,
+        json_mode=json_mode,
+    )
+
+
+def cmd_start(
+    *,
+    base_dir: str,
+    port: str,
+    baud: int,
+    force: bool,
+    json_mode: bool,
+) -> int:
+    existing = check_singleton()
+    if existing and existing.is_alive:
+        if not force:
+            payload = {
+                "schema_version": 1,
+                "timestamp": _now_iso(),
+                "started": False,
+                "message": "Daemon already running",
+                "pid": existing.pid,
+            }
+            _print(payload, json_mode=json_mode)
+            return 1
+        kill_existing_daemon()
+
+    if force:
+        # Best-effort: kill any other EAB instances still holding port locks (covers cases where
+        # multiple daemons exist but only one is referenced by the singleton files).
+        killed: list[int] = []
+        for owner in list_all_locks():
+            if owner.pid == os.getpid():
+                continue
+            try:
+                os.kill(owner.pid, signal.SIGTERM)
+                killed.append(owner.pid)
+            except Exception:
+                pass
+        if killed:
+            time.sleep(0.5)
+            for pid in killed:
+                try:
+                    os.kill(pid, 0)
+                except Exception:
+                    continue
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except Exception:
+                    pass
+
+        # Clean stale lock artifacts from dead processes (safe).
+        cleanup_dead_locks()
+
+    args = [
+        sys.executable,
+        "-m",
+        "eab",
+        "--port",
+        port,
+        "--baud",
+        str(baud),
+        "--base-dir",
+        base_dir,
+    ]
+
+    log_path = "/tmp/eab-daemon.log"
+    err_path = "/tmp/eab-daemon.err"
+
+    daemon_cwd = os.path.dirname(os.path.abspath(__file__))
+    env = dict(os.environ)
+    # Python may run with a "safe path" configuration that doesn't include CWD on sys.path.
+    # Ensure the local checkout is importable when we spawn the daemon.
+    env["PYTHONPATH"] = (
+        daemon_cwd
+        if not env.get("PYTHONPATH")
+        else daemon_cwd + os.pathsep + env["PYTHONPATH"]
+    )
+    with open(log_path, "a", encoding="utf-8") as out, open(err_path, "a", encoding="utf-8") as err:
+        proc = subprocess.Popen(
+            args,
+            stdout=out,
+            stderr=err,
+            cwd=daemon_cwd,
+            env=env,
+            start_new_session=True,
+        )
+
+    payload = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "started": True,
+        "pid": proc.pid,
+        "log_path": log_path,
+        "err_path": err_path,
+    }
+    _print(payload, json_mode=json_mode)
+    return 0
+
+
+def cmd_stop(*, json_mode: bool) -> int:
+    existing = check_singleton()
+    if not existing or not existing.is_alive:
+        payload = {
+            "schema_version": 1,
+            "timestamp": _now_iso(),
+            "stopped": False,
+            "message": "Daemon not running",
+        }
+        _print(payload, json_mode=json_mode)
+        return 1
+
+    ok = kill_existing_daemon()
+    payload = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "stopped": ok,
+        "pid": existing.pid,
+    }
+    _print(payload, json_mode=json_mode)
+    return 0 if ok else 1
+
+
+def cmd_capture_between(
+    *,
+    base_dir: str,
+    start_marker: str,
+    end_marker: str,
+    output_path: str,
+    timeout_s: float,
+    from_start: bool,
+    strip_timestamps: bool,
+    filter_mode: str,
+    decode_base64: bool,
+    json_mode: bool,
+) -> int:
+    log_path = os.path.join(base_dir, "latest.log")
+    result = capture_between_markers(
+        log_path=log_path,
+        start_marker=start_marker,
+        end_marker=end_marker,
+        output_path=output_path,
+        timeout_s=timeout_s,
+        from_end=not from_start,
+        strip_timestamps=strip_timestamps,
+        filter_mode=filter_mode,  # type: ignore[arg-type]
+        decode_base64=decode_base64,
+    )
+
+    payload = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "log_path": log_path,
+        "start_marker": start_marker,
+        "end_marker": end_marker,
+        "output_path": output_path,
+        "result": asdict(result),
+    }
+    _print(payload, json_mode=json_mode)
+    return 0 if (result.start_seen and result.end_seen) else 1
+
+
+def cmd_flash(
+    *,
+    firmware: str,
+    chip: str,
+    address: Optional[str],
+    port: Optional[str],
+    tool: Optional[str],
+    baud: int,
+    connect_under_reset: bool,
+    json_mode: bool,
+) -> int:
+    """Flash firmware to device using chip-specific tool."""
+    started = time.time()
+
+    try:
+        profile = get_chip_profile(chip)
+    except ValueError as e:
+        _print({"error": str(e)}, json_mode=json_mode)
+        return 2
+
+    # Build flash command from chip profile
+    kwargs = {"baud": baud, "connect_under_reset": connect_under_reset}
+    if tool:
+        kwargs["tool"] = tool
+
+    flash_cmd = profile.get_flash_command(
+        firmware_path=firmware,
+        port=port or "",
+        address=address or profile.flash_tool,  # Use default if not specified
+        **kwargs,
+    )
+
+    # For STM32, address defaults to 0x08000000 if not specified
+    if chip.lower().startswith("stm32") and not address:
+        flash_cmd = profile.get_flash_command(
+            firmware_path=firmware,
+            port=port or "",
+            address="0x08000000",
+            **kwargs,
+        )
+
+    # Execute flash command
+    cmd_list = [flash_cmd.tool] + flash_cmd.args
+    try:
+        result = subprocess.run(
+            cmd_list,
+            capture_output=True,
+            text=True,
+            timeout=flash_cmd.timeout,
+        )
+        success = result.returncode == 0
+        stdout = result.stdout
+        stderr = result.stderr
+    except subprocess.TimeoutExpired:
+        success = False
+        stdout = ""
+        stderr = f"Timeout after {flash_cmd.timeout}s"
+    except FileNotFoundError:
+        success = False
+        stdout = ""
+        stderr = f"Tool not found: {flash_cmd.tool}. Install with: brew install stlink"
+
+    # Auto-retry with connect-under-reset if connection failed (STM32 only)
+    retried_with_cur = False
+    if not success and chip.lower().startswith("stm32") and not connect_under_reset:
+        if "Can not connect" in stderr or "unable to get core" in stderr.lower():
+            # Retry with connect-under-reset using STM32CubeProgrammer
+            retried_with_cur = True
+            kwargs["connect_under_reset"] = True
+            flash_cmd = profile.get_flash_command(
+                firmware_path=firmware,
+                port=port or "",
+                address=address or "0x08000000",
+                **kwargs,
+            )
+            cmd_list = [flash_cmd.tool] + flash_cmd.args
+            try:
+                result = subprocess.run(
+                    cmd_list,
+                    capture_output=True,
+                    text=True,
+                    timeout=flash_cmd.timeout,
+                )
+                success = result.returncode == 0
+                stdout = result.stdout
+                stderr = result.stderr
+            except subprocess.TimeoutExpired:
+                stdout = ""
+                stderr = f"Timeout after {flash_cmd.timeout}s (connect-under-reset retry)"
+            except FileNotFoundError:
+                stdout = ""
+                stderr = f"Tool not found: {flash_cmd.tool}"
+
+    duration_ms = int((time.time() - started) * 1000)
+
+    payload = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "success": success,
+        "chip": chip,
+        "firmware": firmware,
+        "address": address,
+        "tool": flash_cmd.tool,
+        "command": cmd_list,
+        "retried_with_connect_under_reset": retried_with_cur,
+        "stdout": stdout,
+        "stderr": stderr,
+        "duration_ms": duration_ms,
+    }
+    _print(payload, json_mode=json_mode)
+    return 0 if success else 1
+
+
+def cmd_preflight_hw(
+    *,
+    chip: str,
+    stock_firmware: str,
+    address: Optional[str],
+    timeout: int,
+    json_mode: bool,
+) -> int:
+    """
+    Verify hardware chain by flashing stock firmware and checking functionality.
+
+    This is the FIRST step before any debugging session. It answers:
+    - Is the hardware OK?
+    - Is the debugger OK?
+    - If stock fails, it's hardware/driver - not your code.
+
+    Steps:
+    1. Flash stock firmware
+    2. Wait for boot
+    3. Check if CPU is running (not stuck in infinite loop)
+    4. Report PASS/FAIL with diagnosis
+    """
+    started = time.time()
+    checks = []
+    overall_pass = True
+
+    try:
+        profile = get_chip_profile(chip)
+    except ValueError as e:
+        _print({"error": str(e), "success": False}, json_mode=json_mode)
+        return 2
+
+    # Step 1: Flash stock firmware
+    flash_address = address or ("0x08000000" if chip.lower().startswith("stm32") else "0x0")
+    flash_cmd = profile.get_flash_command(
+        firmware_path=stock_firmware,
+        port="",
+        address=flash_address,
+    )
+
+    cmd_list = [flash_cmd.tool] + flash_cmd.args
+    try:
+        result = subprocess.run(
+            cmd_list,
+            capture_output=True,
+            text=True,
+            timeout=flash_cmd.timeout,
+        )
+        flash_success = result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        flash_success = False
+        result = None
+
+    checks.append({
+        "name": "flash_stock_firmware",
+        "passed": flash_success,
+        "message": "Stock firmware flashed successfully" if flash_success else f"Flash failed: {result.stderr if result else str(e)}",
+    })
+
+    if not flash_success:
+        overall_pass = False
+        _print({
+            "success": False,
+            "checks": checks,
+            "diagnosis": "Flash failed - check debugger connection, try power cycle",
+            "duration_ms": int((time.time() - started) * 1000),
+        }, json_mode=json_mode)
+        return 1
+
+    # Step 2: Wait for boot
+    time.sleep(timeout / 2)  # Give firmware time to boot
+
+    # Step 3: Check if CPU is running (not stuck)
+    # Use OpenOCD to halt, get PC, resume, halt again, compare PCs
+    bridge = OpenOCDBridge("/tmp/eab-session")
+
+    # Try to start OpenOCD if not running
+    try:
+        openocd_config = profile.get_openocd_config()
+        bridge.start(
+            interface_cfg=openocd_config.interface_cfg,
+            target_cfg=openocd_config.target_cfg,
+        )
+        time.sleep(1)  # Let OpenOCD connect
+    except Exception as e:
+        checks.append({
+            "name": "openocd_start",
+            "passed": False,
+            "message": f"Failed to start OpenOCD: {e}",
+        })
+        overall_pass = False
+
+    # Sample PC twice to detect if CPU is stuck
+    pc_samples = []
+    cpu_stuck = False
+
+    try:
+        # First sample
+        bridge.cmd("halt", timeout_s=5)
+        time.sleep(0.2)
+        halt_output1 = bridge.cmd("reg pc", timeout_s=2)
+        pc_samples.append(halt_output1)
+
+        # Resume and wait
+        bridge.cmd("resume", timeout_s=2)
+        time.sleep(1)
+
+        # Second sample
+        bridge.cmd("halt", timeout_s=5)
+        time.sleep(0.2)
+        halt_output2 = bridge.cmd("reg pc", timeout_s=2)
+        pc_samples.append(halt_output2)
+
+        # Check if PC changed (indicating CPU is running, not stuck)
+        # Parse PC from output (format varies by OpenOCD version)
+        import re
+        pc_pattern = r"pc[:\s]+(?:0x)?([0-9a-fA-F]+)"
+
+        pc1_match = re.search(pc_pattern, halt_output1, re.IGNORECASE)
+        pc2_match = re.search(pc_pattern, halt_output2, re.IGNORECASE)
+
+        if pc1_match and pc2_match:
+            pc1 = int(pc1_match.group(1), 16)
+            pc2 = int(pc2_match.group(1), 16)
+
+            # If PC is in a very small range (< 16 bytes), likely stuck in tight loop
+            pc_diff = abs(pc2 - pc1)
+            cpu_stuck = pc_diff < 16
+
+            checks.append({
+                "name": "cpu_running",
+                "passed": not cpu_stuck,
+                "message": f"CPU running (PC moved {pc_diff} bytes)" if not cpu_stuck else f"CPU STUCK at 0x{pc1:08x} (PC unchanged)",
+                "pc_samples": [f"0x{pc1:08x}", f"0x{pc2:08x}"],
+            })
+        else:
+            # Couldn't parse PC, try simpler check - did we get any output?
+            got_output = bool(halt_output1.strip() and halt_output2.strip())
+            checks.append({
+                "name": "cpu_running",
+                "passed": got_output,
+                "message": "CPU responding to debug commands" if got_output else "No response from CPU",
+            })
+            cpu_stuck = not got_output
+
+    except Exception as e:
+        checks.append({
+            "name": "cpu_running",
+            "passed": False,
+            "message": f"Failed to check CPU state: {e}",
+        })
+        cpu_stuck = True
+    finally:
+        # Resume CPU and stop OpenOCD
+        try:
+            bridge.cmd("resume", timeout_s=2)
+        except:
+            pass
+        bridge.stop()
+
+    if cpu_stuck:
+        overall_pass = False
+
+    # Final diagnosis
+    if overall_pass:
+        diagnosis = "Hardware chain VERIFIED - ready for custom firmware"
+    elif not flash_success:
+        diagnosis = "Flash failed - check debugger connection, try power cycle"
+    elif cpu_stuck:
+        diagnosis = "CPU stuck in infinite loop - stock firmware has bug or hardware issue"
+    else:
+        diagnosis = "Preflight check failed - see individual checks"
+
+    duration_ms = int((time.time() - started) * 1000)
+
+    payload = {
+        "success": overall_pass,
+        "checks": checks,
+        "diagnosis": diagnosis,
+        "chip": chip,
+        "stock_firmware": stock_firmware,
+        "duration_ms": duration_ms,
+    }
+
+    _print(payload, json_mode=json_mode)
+    return 0 if overall_pass else 1
+
+
+def cmd_erase(
+    *,
+    chip: str,
+    port: Optional[str],
+    tool: Optional[str],
+    connect_under_reset: bool,
+    json_mode: bool,
+) -> int:
+    """Erase flash memory using chip-specific tool."""
+    started = time.time()
+
+    try:
+        profile = get_chip_profile(chip)
+    except ValueError as e:
+        _print({"error": str(e)}, json_mode=json_mode)
+        return 2
+
+    kwargs = {"connect_under_reset": connect_under_reset}
+    if tool:
+        kwargs["tool"] = tool
+
+    erase_cmd = profile.get_erase_command(port=port or "", **kwargs)
+
+    cmd_list = [erase_cmd.tool] + erase_cmd.args
+    try:
+        result = subprocess.run(
+            cmd_list,
+            capture_output=True,
+            text=True,
+            timeout=erase_cmd.timeout,
+        )
+        success = result.returncode == 0
+        stdout = result.stdout
+        stderr = result.stderr
+    except subprocess.TimeoutExpired:
+        success = False
+        stdout = ""
+        stderr = f"Timeout after {erase_cmd.timeout}s"
+    except FileNotFoundError:
+        success = False
+        stdout = ""
+        stderr = f"Tool not found: {erase_cmd.tool}"
+
+    duration_ms = int((time.time() - started) * 1000)
+
+    payload = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "success": success,
+        "chip": chip,
+        "tool": erase_cmd.tool,
+        "command": cmd_list,
+        "stdout": stdout,
+        "stderr": stderr,
+        "duration_ms": duration_ms,
+    }
+    _print(payload, json_mode=json_mode)
+    return 0 if success else 1
+
+
+def cmd_chip_info(
+    *,
+    chip: str,
+    port: Optional[str],
+    json_mode: bool,
+) -> int:
+    """Get chip information using chip-specific tool."""
+    started = time.time()
+
+    try:
+        profile = get_chip_profile(chip)
+    except ValueError as e:
+        _print({"error": str(e)}, json_mode=json_mode)
+        return 2
+
+    info_cmd = profile.get_chip_info_command(port=port or "")
+
+    cmd_list = [info_cmd.tool] + info_cmd.args
+    try:
+        result = subprocess.run(
+            cmd_list,
+            capture_output=True,
+            text=True,
+            timeout=info_cmd.timeout,
+        )
+        success = result.returncode == 0
+        stdout = result.stdout
+        stderr = result.stderr
+    except subprocess.TimeoutExpired:
+        success = False
+        stdout = ""
+        stderr = f"Timeout after {info_cmd.timeout}s"
+    except FileNotFoundError:
+        success = False
+        stdout = ""
+        stderr = f"Tool not found: {info_cmd.tool}"
+
+    duration_ms = int((time.time() - started) * 1000)
+
+    payload = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "success": success,
+        "chip": chip,
+        "tool": info_cmd.tool,
+        "command": cmd_list,
+        "stdout": stdout,
+        "stderr": stderr,
+        "duration_ms": duration_ms,
+    }
+    _print(payload, json_mode=json_mode)
+    return 0 if success else 1
+
+
+def _find_stm32_programmer_cli() -> str:
+    """Find STM32_Programmer_CLI executable."""
+    import glob as glob_mod
+    path = shutil.which("STM32_Programmer_CLI")
+    if path:
+        return path
+    # Common locations on macOS
+    patterns = [
+        "/Applications/STM32CubeIDE.app/Contents/Eclipse/plugins/com.st.stm32cube.ide.mcu.externaltools.cubeprogrammer.*/tools/bin/STM32_Programmer_CLI",
+    ]
+    for pattern in patterns:
+        matches = glob_mod.glob(pattern)
+        if matches:
+            return sorted(matches)[-1]
+    return "STM32_Programmer_CLI"
+
+
+def cmd_reset(
+    *,
+    chip: str,
+    method: str,
+    connect_under_reset: bool,
+    json_mode: bool,
+) -> int:
+    """Hardware reset device using st-flash reset or STM32CubeProgrammer."""
+    started = time.time()
+    retried_with_cur = False
+
+    # For STM32, use st-flash reset command directly
+    if chip.lower().startswith("stm32"):
+        # Try st-flash first (unless connect-under-reset requested)
+        if not connect_under_reset:
+            cmd_list = ["st-flash", "reset"]
+            try:
+                result = subprocess.run(
+                    cmd_list,
+                    capture_output=True,
+                    text=True,
+                    timeout=30.0,
+                )
+                success = result.returncode == 0
+                stdout = result.stdout
+                stderr = result.stderr
+
+                # Auto-retry with connect-under-reset if normal reset fails
+                if not success and ("Can not connect" in stderr or "unable to get core" in stderr.lower()):
+                    connect_under_reset = True
+                    retried_with_cur = True
+            except subprocess.TimeoutExpired:
+                success = False
+                stdout = ""
+                stderr = "Timeout after 30s"
+                connect_under_reset = True
+                retried_with_cur = True
+            except FileNotFoundError:
+                success = False
+                stdout = ""
+                stderr = "st-flash not found. Install with: brew install stlink"
+
+        # Use STM32CubeProgrammer with connect-under-reset
+        if connect_under_reset:
+            cubeprog = _find_stm32_programmer_cli()
+            cmd_list = [cubeprog, "-c", "port=SWD mode=UR reset=HWrst", "-rst"]
+            try:
+                result = subprocess.run(
+                    cmd_list,
+                    capture_output=True,
+                    text=True,
+                    timeout=30.0,
+                )
+                success = result.returncode == 0
+                stdout = result.stdout
+                stderr = result.stderr
+            except subprocess.TimeoutExpired:
+                success = False
+                stdout = ""
+                stderr = "Timeout after 30s (connect-under-reset)"
+            except FileNotFoundError:
+                success = False
+                stdout = ""
+                stderr = f"STM32CubeProgrammer not found: {cubeprog}"
+    else:
+        # For ESP32, would need OpenOCD or esptool
+        success = False
+        stdout = ""
+        stderr = f"Reset for {chip} not yet implemented. Use OpenOCD: eabctl openocd cmd --command 'reset run'"
+        cmd_list = []
+
+    duration_ms = int((time.time() - started) * 1000)
+
+    payload = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "success": success,
+        "chip": chip,
+        "method": method,
+        "connect_under_reset": connect_under_reset,
+        "retried_with_connect_under_reset": retried_with_cur,
+        "command": cmd_list,
+        "stdout": stdout,
+        "stderr": stderr,
+        "duration_ms": duration_ms,
+    }
+    _print(payload, json_mode=json_mode)
+    return 0 if success else 1
+
+
+def cmd_diagnose(*, base_dir: str, json_mode: bool) -> int:
+    existing = check_singleton()
+    status_path = os.path.join(base_dir, "status.json")
+
+    checks: list[dict[str, str]] = []
+    recommendations: list[str] = []
+
+    if existing and existing.is_alive:
+        checks.append({"name": "daemon", "status": "ok", "message": f"Running PID {existing.pid}"})
+    else:
+        checks.append({"name": "daemon", "status": "error", "message": "Daemon not running"})
+        recommendations.append("Run: eab-control start")
+
+    status: Optional[dict[str, Any]] = None
+    try:
+        status = json.loads(_read_text(status_path))
+        checks.append({"name": "status_json", "status": "ok", "message": f"Readable: {status_path}"})
+    except FileNotFoundError:
+        checks.append({"name": "status_json", "status": "error", "message": f"Missing: {status_path}"})
+        recommendations.append("Run: eab-control start")
+    except json.JSONDecodeError:
+        checks.append({"name": "status_json", "status": "error", "message": f"Invalid JSON: {status_path}"})
+
+    if status:
+        conn = status.get("connection", {})
+        conn_status = conn.get("status")
+        if conn_status == "connected":
+            checks.append({"name": "connection", "status": "ok", "message": f"Connected: {conn.get('port')}"})
+        elif conn_status:
+            checks.append({"name": "connection", "status": "warn", "message": f"{conn_status}: {conn.get('port')}"})
+            recommendations.append("Try: eab-control reset")
+        else:
+            checks.append({"name": "connection", "status": "warn", "message": "Unknown connection status"})
+
+        health = status.get("health", {})
+        health_status = health.get("status")
+        idle_seconds = health.get("idle_seconds")
+        if health_status in {"healthy", "idle"}:
+            checks.append({"name": "health", "status": "ok", "message": f"{health_status} (idle={idle_seconds}s)"})
+        elif health_status:
+            checks.append({"name": "health", "status": "warn", "message": f"{health_status} (idle={idle_seconds}s)"})
+            recommendations.append("Check cable; then run: eab-control reset")
+        else:
+            checks.append({"name": "health", "status": "warn", "message": "Missing health.status"})
+
+        patterns = status.get("patterns", {})
+        watchdog = int(patterns.get("WATCHDOG", 0) or 0)
+        boot = int(patterns.get("BOOT", 0) or 0)
+        if watchdog >= 25 or boot >= 25:
+            checks.append(
+                {
+                    "name": "boot_loop",
+                    "status": "warn",
+                    "message": f"High boot indicators (WATCHDOG={watchdog}, BOOT={boot})",
+                }
+            )
+            recommendations.append("Device may be in a boot loop. Consider: eab-control flash <project_dir>")
+        else:
+            checks.append({"name": "boot_loop", "status": "ok", "message": f"WATCHDOG={watchdog}, BOOT={boot}"})
+
+    healthy = all(c["status"] == "ok" for c in checks)
+
+    payload = {
+        "schema_version": 1,
+        "timestamp": _now_iso(),
+        "healthy": healthy,
+        "checks": checks,
+        "recommendations": recommendations,
+    }
+    _print(payload, json_mode=json_mode)
+    return 0 if healthy else 1
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    if argv is None:
+        argv = sys.argv[1:]
+
+    # Agent ergonomics: allow global flags anywhere (before or after subcommand).
+    # argparse doesn't support this reliably with subparsers, so we reorder.
+    global_args: list[str] = []
+    rest: list[str] = []
+    i = 0
+    while i < len(argv):
+        token = argv[i]
+        if token == "--json":
+            global_args.append(token)
+            i += 1
+            continue
+        if token.startswith("--base-dir="):
+            global_args.append(token)
+            i += 1
+            continue
+        if token == "--base-dir":
+            # Needs a value.
+            if i + 1 >= len(argv):
+                rest.append(token)
+                i += 1
+                continue
+            global_args.extend([token, argv[i + 1]])
+            i += 2
+            continue
+
+        rest.append(token)
+        i += 1
+
+    argv = global_args + rest
+
+    parser = argparse.ArgumentParser(prog="eabctl", description="EAB agent-friendly CLI")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s 1.0.0 (embedded-agent-bridge)",
+    )
+    parser.add_argument("--json", action="store_true", help="Output machine-parseable JSON")
+    parser.add_argument(
+        "--base-dir",
+        default=None,
+        help=f"Override session dir (default: daemon base_dir or {DEFAULT_BASE_DIR})",
+    )
+
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("status", help="Show daemon + device status")
+
+    p_tail = sub.add_parser("tail", help="Show last N lines of latest.log")
+    p_tail.add_argument("-n", "--lines", type=int, default=50)
+
+    p_alerts = sub.add_parser("alerts", help="Show last N lines of alerts.log")
+    p_alerts.add_argument("-n", "--lines", type=int, default=20)
+
+    p_send = sub.add_parser("send", help="Queue a command to the device")
+    p_send.add_argument("text")
+    p_send.add_argument("--await", dest="await_ack", action="store_true", help="Wait for daemon to log the command")
+    p_send.add_argument(
+        "--await-event",
+        action="store_true",
+        help="Wait for events.jsonl to confirm the command was sent",
+    )
+    p_send.add_argument("--timeout", type=float, default=10.0)
+
+    p_wait = sub.add_parser("wait", help="Wait for a regex to appear in latest.log")
+    p_wait.add_argument("pattern")
+    p_wait.add_argument("--timeout", type=float, default=30.0)
+
+    p_events = sub.add_parser("events", help="Show last N events from events.jsonl")
+    p_events.add_argument("-n", "--lines", type=int, default=50)
+
+    p_wait_event = sub.add_parser("wait-event", help="Wait for an event in events.jsonl")
+    p_wait_event.add_argument("--type", dest="event_type", help="Event type to match")
+    p_wait_event.add_argument("--contains", help="Substring to match in serialized event")
+    p_wait_event.add_argument("--command", help="Match data.command exactly")
+    p_wait_event.add_argument("--timeout", type=float, default=30.0)
+
+    p_pause = sub.add_parser("pause", help="Pause daemon (release port) for N seconds")
+    p_pause.add_argument("seconds", type=int, nargs="?", default=120)
+
+    sub.add_parser("resume", help="Resume daemon early (remove pause file)")
+
+    p_openocd = sub.add_parser("openocd", help="Manage OpenOCD (USB-JTAG) through EAB")
+    p_openocd.add_argument("action", choices=["status", "start", "stop", "cmd"])
+    p_openocd.add_argument("--chip", default="esp32s3")
+    p_openocd.add_argument("--vid", default="0x303a")
+    p_openocd.add_argument("--pid", default="0x1001")
+    p_openocd.add_argument("--telnet-port", type=int, default=DEFAULT_TELNET_PORT)
+    p_openocd.add_argument("--gdb-port", type=int, default=DEFAULT_GDB_PORT)
+    p_openocd.add_argument("--tcl-port", type=int, default=DEFAULT_TCL_PORT)
+    p_openocd.add_argument("--timeout", type=float, default=2.0)
+    p_openocd.add_argument("--command", default="", help="Command for 'openocd cmd'")
+
+    p_gdb = sub.add_parser("gdb", help="Run one-shot GDB commands through EAB (requires OpenOCD)")
+    p_gdb.add_argument("--chip", default="esp32s3")
+    p_gdb.add_argument("--target", default=f"localhost:{DEFAULT_GDB_PORT}")
+    p_gdb.add_argument("--elf", default=None)
+    p_gdb.add_argument("--gdb", dest="gdb_path", default=None)
+    p_gdb.add_argument("--timeout", type=float, default=60.0)
+    p_gdb.add_argument("--cmd", dest="commands", action="append", default=[], help="GDB command (repeatable)")
+
+    p_stream = sub.add_parser("stream", help="Configure high-speed data stream mode")
+    p_stream.add_argument("action", choices=["start", "stop"])
+    p_stream.add_argument("--mode", choices=["raw", "base64"], default="raw")
+    p_stream.add_argument("--chunk", type=int, default=16384, help="Chunk size for raw reads")
+    p_stream.add_argument("--marker", default=None, help="Marker line to start streaming")
+    p_stream.add_argument(
+        "--no-patterns",
+        action="store_true",
+        help="Disable pattern matching while streaming",
+    )
+    p_stream.add_argument(
+        "--truncate",
+        action="store_true",
+        help="Truncate data.bin when enabling stream",
+    )
+
+    p_recv = sub.add_parser("recv", help="Read bytes from data.bin")
+    p_recv.add_argument("--offset", type=int, required=True)
+    p_recv.add_argument("--length", type=int, required=True)
+    p_recv.add_argument("--out", dest="output_path", default=None)
+    p_recv.add_argument("--base64", action="store_true")
+
+    p_recv_latest = sub.add_parser("recv-latest", help="Read last N bytes from data.bin")
+    p_recv_latest.add_argument("--bytes", dest="length", type=int, required=True)
+    p_recv_latest.add_argument("--out", dest="output_path", default=None)
+    p_recv_latest.add_argument("--base64", action="store_true")
+
+    p_start = sub.add_parser("start", help="Start daemon in background (logs to /tmp)")
+    p_start.add_argument("--port", default="auto")
+    p_start.add_argument("--baud", type=int, default=115200)
+    p_start.add_argument("--force", action="store_true")
+
+    sub.add_parser("stop", help="Stop running daemon")
+
+    p_capture = sub.add_parser(
+        "capture-between",
+        help="Capture payload lines between markers (defaults to base64-only) and write to a file",
+    )
+    p_capture.add_argument("start_marker")
+    p_capture.add_argument("end_marker")
+    p_capture.add_argument("output")
+    p_capture.add_argument("--timeout", type=float, default=120.0)
+    p_capture.add_argument(
+        "--from-start",
+        action="store_true",
+        help="Scan from start of log instead of tailing new lines",
+    )
+    p_capture.add_argument(
+        "--no-strip-timestamps",
+        action="store_true",
+        help="Do not remove [HH:MM:SS.mmm] prefixes before filtering",
+    )
+    p_capture.add_argument(
+        "--filter",
+        choices=["base64", "none"],
+        default="base64",
+        help="Payload filter mode (default: base64)",
+    )
+    p_capture.add_argument(
+        "--decode-base64",
+        action="store_true",
+        help="Base64-decode captured payload and write bytes to output file",
+    )
+
+    sub.add_parser("diagnose", help="Run basic health checks and print recommendations")
+
+    # Flash operations (chip-agnostic)
+    p_flash = sub.add_parser("flash", help="Flash firmware to device")
+    p_flash.add_argument("firmware", help="Path to firmware binary (.bin/.hex)")
+    p_flash.add_argument("--chip", required=True, help="Chip type (esp32s3, stm32l4, etc.)")
+    p_flash.add_argument("--address", default=None, help="Flash address (default: chip-specific)")
+    p_flash.add_argument("--port", default=None, help="Serial port (ESP32) or ignored (STM32)")
+    p_flash.add_argument("--tool", default=None, help="Flash tool override (st-flash, esptool.py)")
+    p_flash.add_argument("--baud", type=int, default=921600, help="Baud rate (ESP32 only)")
+    p_flash.add_argument("--connect-under-reset", action="store_true",
+                        help="STM32: Connect while holding reset (for crashed chips)")
+
+    p_erase = sub.add_parser("erase", help="Erase flash memory")
+    p_erase.add_argument("--chip", required=True, help="Chip type (esp32s3, stm32l4, etc.)")
+    p_erase.add_argument("--port", default=None, help="Serial port (ESP32) or ignored (STM32)")
+    p_erase.add_argument("--tool", default=None, help="Erase tool override")
+    p_erase.add_argument("--connect-under-reset", action="store_true",
+                        help="STM32: Connect while holding reset (for crashed chips)")
+
+    p_chip_info = sub.add_parser("chip-info", help="Get chip information")
+    p_chip_info.add_argument("--chip", required=True, help="Chip type (esp32s3, stm32l4, etc.)")
+    p_chip_info.add_argument("--port", default=None, help="Serial port (ESP32) or ignored (STM32)")
+
+    p_reset = sub.add_parser("reset", help="Hardware reset device")
+    p_reset.add_argument("--chip", required=True, help="Chip type (esp32s3, stm32l4, etc.)")
+    p_reset.add_argument("--method", choices=["hard", "soft", "bootloader"], default="hard")
+    p_reset.add_argument("--connect-under-reset", action="store_true",
+                        help="STM32: Connect while holding reset (for crashed chips)")
+
+    # Hardware verification (preflight check)
+    p_preflight = sub.add_parser("preflight-hw", help="Verify hardware by flashing stock firmware")
+    p_preflight.add_argument("stock_firmware", help="Path to known-good stock firmware binary")
+    p_preflight.add_argument("--chip", required=True, help="Chip type (esp32s3, stm32l4, etc.)")
+    p_preflight.add_argument("--address", default=None, help="Flash address (default: chip-specific)")
+    p_preflight.add_argument("--timeout", type=int, default=10, help="Boot timeout in seconds")
+
+    args = parser.parse_args(argv)
+    base_dir = _resolve_base_dir(args.base_dir)
+
+    if args.cmd == "status":
+        return cmd_status(base_dir=base_dir, json_mode=args.json)
+    if args.cmd == "tail":
+        return cmd_tail(base_dir=base_dir, lines=args.lines, json_mode=args.json)
+    if args.cmd == "alerts":
+        return cmd_alerts(base_dir=base_dir, lines=args.lines, json_mode=args.json)
+    if args.cmd == "events":
+        return cmd_events(base_dir=base_dir, lines=args.lines, json_mode=args.json)
+    if args.cmd == "send":
+        return cmd_send(
+            base_dir=base_dir,
+            text=args.text,
+            await_ack=args.await_ack,
+            await_event=args.await_event,
+            timeout_s=args.timeout,
+            json_mode=args.json,
+        )
+    if args.cmd == "wait":
+        return cmd_wait(base_dir=base_dir, pattern=args.pattern, timeout_s=args.timeout, json_mode=args.json)
+    if args.cmd == "wait-event":
+        return cmd_wait_event(
+            base_dir=base_dir,
+            event_type=args.event_type,
+            contains=args.contains,
+            command=args.command,
+            timeout_s=args.timeout,
+            json_mode=args.json,
+        )
+    if args.cmd == "pause":
+        return cmd_pause(base_dir=base_dir, seconds=args.seconds, json_mode=args.json)
+    if args.cmd == "resume":
+        return cmd_resume(base_dir=base_dir, json_mode=args.json)
+    if args.cmd == "openocd":
+        if args.action == "status":
+            return cmd_openocd_status(base_dir=base_dir, json_mode=args.json)
+        if args.action == "start":
+            return cmd_openocd_start(
+                base_dir=base_dir,
+                chip=args.chip,
+                vid=args.vid,
+                pid=args.pid,
+                telnet_port=args.telnet_port,
+                gdb_port=args.gdb_port,
+                tcl_port=args.tcl_port,
+                json_mode=args.json,
+            )
+        if args.action == "stop":
+            return cmd_openocd_stop(base_dir=base_dir, json_mode=args.json)
+        if args.action == "cmd":
+            if not args.command:
+                _print({"error": "missing --command"}, json_mode=args.json)
+                return 2
+            return cmd_openocd_cmd(
+                base_dir=base_dir,
+                command=args.command,
+                telnet_port=args.telnet_port,
+                timeout_s=args.timeout,
+                json_mode=args.json,
+            )
+    if args.cmd == "gdb":
+        if not args.commands:
+            _print({"error": "missing --cmd (repeatable)"}, json_mode=args.json)
+            return 2
+        return cmd_gdb(
+            base_dir=base_dir,
+            chip=args.chip,
+            target=args.target,
+            elf=args.elf,
+            gdb_path=args.gdb_path,
+            commands=args.commands,
+            timeout_s=args.timeout,
+            json_mode=args.json,
+        )
+    if args.cmd == "stream":
+        if args.action == "start":
+            return cmd_stream_start(
+                base_dir=base_dir,
+                mode=args.mode,
+                chunk_size=args.chunk,
+                marker=args.marker,
+                pattern_matching=not args.no_patterns,
+                truncate=args.truncate,
+                json_mode=args.json,
+            )
+        return cmd_stream_stop(base_dir=base_dir, json_mode=args.json)
+    if args.cmd == "recv":
+        return cmd_recv(
+            base_dir=base_dir,
+            offset=args.offset,
+            length=args.length,
+            output_path=args.output_path,
+            base64_output=args.base64,
+            json_mode=args.json,
+        )
+    if args.cmd == "recv-latest":
+        return cmd_recv_latest(
+            base_dir=base_dir,
+            length=args.length,
+            output_path=args.output_path,
+            base64_output=args.base64,
+            json_mode=args.json,
+        )
+    if args.cmd == "start":
+        return cmd_start(
+            base_dir=base_dir,
+            port=args.port,
+            baud=args.baud,
+            force=args.force,
+            json_mode=args.json,
+        )
+    if args.cmd == "stop":
+        return cmd_stop(json_mode=args.json)
+    if args.cmd == "capture-between":
+        return cmd_capture_between(
+            base_dir=base_dir,
+            start_marker=args.start_marker,
+            end_marker=args.end_marker,
+            output_path=args.output,
+            timeout_s=args.timeout,
+            from_start=args.from_start,
+            strip_timestamps=not args.no_strip_timestamps,
+            filter_mode=args.filter,
+            decode_base64=args.decode_base64,
+            json_mode=args.json,
+        )
+    if args.cmd == "diagnose":
+        return cmd_diagnose(base_dir=base_dir, json_mode=args.json)
+    if args.cmd == "flash":
+        return cmd_flash(
+            firmware=args.firmware,
+            chip=args.chip,
+            address=args.address,
+            port=args.port,
+            tool=args.tool,
+            baud=args.baud,
+            connect_under_reset=getattr(args, "connect_under_reset", False),
+            json_mode=args.json,
+        )
+    if args.cmd == "erase":
+        return cmd_erase(
+            chip=args.chip,
+            port=args.port,
+            tool=args.tool,
+            connect_under_reset=getattr(args, "connect_under_reset", False),
+            json_mode=args.json,
+        )
+    if args.cmd == "chip-info":
+        return cmd_chip_info(
+            chip=args.chip,
+            port=args.port,
+            json_mode=args.json,
+        )
+    if args.cmd == "reset":
+        return cmd_reset(
+            chip=args.chip,
+            method=args.method,
+            connect_under_reset=getattr(args, "connect_under_reset", False),
+            json_mode=args.json,
+        )
+    if args.cmd == "preflight-hw":
+        return cmd_preflight_hw(
+            chip=args.chip,
+            stock_firmware=args.stock_firmware,
+            address=args.address,
+            timeout=args.timeout,
+            json_mode=args.json,
+        )
+
+    parser.error(f"Unknown command: {args.cmd}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,61 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "embedded-agent-bridge"
+version = "1.0.0"
+description = "AI agent bridge for embedded systems debugging"
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "MIT"}
+authors = [
+    {name = "Shane Mattner"}
+]
+keywords = ["embedded", "serial", "esp32", "stm32", "debugging", "ai-agent"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Embedded Systems",
+    "Topic :: System :: Hardware",
+]
+
+dependencies = [
+    "pyserial>=3.5",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=9",
+    "pytest-cov>=6",
+]
+
+[project.scripts]
+eab = "eab.daemon:main"
+eab-control = "eab.control:main"
+
+[project.urls]
+Homepage = "https://github.com/shanemattner/embedded-agent-bridge"
+Repository = "https://github.com/shanemattner/embedded-agent-bridge"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["eab*"]
+exclude = ["eab.tests*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests", "eab/tests"]
+python_files = "test_*.py"
+python_classes = "Test*"
+python_functions = "test_*"
+addopts = "-v --tb=short"
+
+[tool.coverage.run]
+source = ["eab"]
+omit = ["eab/tests/*", "*/tests/*"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for embedded-agent-bridge package."""

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -1,0 +1,182 @@
+"""
+Tests for CLI entry points (eab and eab-control).
+
+These tests verify that the entry points are properly configured and
+that basic CLI functionality works (--help, --version, argument parsing).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+class TestDaemonEntryPoint:
+    """Tests for the 'eab' daemon CLI entry point."""
+
+    def test_daemon_main_accepts_argv(self):
+        """The main() function should accept an optional argv parameter."""
+        from eab.daemon import main
+
+        # Should not raise an exception
+        # Note: We can't actually run the daemon in tests without mocking,
+        # but we can verify the signature accepts argv
+        import inspect
+        sig = inspect.signature(main)
+        assert "argv" in sig.parameters
+        # The parameter should have a default (None)
+        assert sig.parameters["argv"].default is None
+        # And the annotation should be Optional (either old-style or new-style union)
+        annotation_str = str(sig.parameters["argv"].annotation)
+        assert "None" in annotation_str and "list" in annotation_str
+
+    def test_daemon_main_returns_int(self):
+        """The main() function should return an int exit code."""
+        from eab.daemon import main
+
+        import inspect
+        sig = inspect.signature(main)
+        assert sig.return_annotation == int or sig.return_annotation == "int"
+
+    def test_daemon_help_flag(self):
+        """Running with --help should show help and exit with code 0."""
+        from eab.daemon import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--help"])
+        assert exc_info.value.code == 0
+
+    def test_daemon_version_flag(self):
+        """Running with --version should show version and exit."""
+        from eab.daemon import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--version"])
+        # argparse version action exits with code 0
+        assert exc_info.value.code == 0
+
+    def test_daemon_list_flag(self):
+        """Running with --list should list serial ports and exit cleanly."""
+        from eab.daemon import main
+
+        # This should return 0 (success)
+        result = main(["--list"])
+        assert result == 0
+
+
+class TestControlEntryPoint:
+    """Tests for the 'eab-control' CLI entry point."""
+
+    def test_control_main_accepts_argv(self):
+        """The main() function should accept an optional argv parameter."""
+        from eab.control import main
+
+        import inspect
+        sig = inspect.signature(main)
+        assert "argv" in sig.parameters
+        assert sig.parameters["argv"].default is not None or sig.parameters["argv"].annotation
+
+    def test_control_main_returns_int(self):
+        """The main() function should return an int exit code."""
+        from eab.control import main
+
+        import inspect
+        sig = inspect.signature(main)
+        assert sig.return_annotation == int or sig.return_annotation == "int"
+
+    def test_control_help_flag(self):
+        """Running with --help should show help and exit with code 0."""
+        from eab.control import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--help"])
+        assert exc_info.value.code == 0
+
+    def test_control_version_flag(self):
+        """Running with --version should show version and exit."""
+        from eab.control import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main(["--version"])
+        assert exc_info.value.code == 0
+
+    def test_control_status_json(self):
+        """Running 'status --json' should work (even if daemon not running)."""
+        from eab.control import main
+
+        # status command should return 1 if daemon not running, but should not crash
+        result = main(["status", "--json"])
+        assert isinstance(result, int)
+
+
+class TestModuleExecution:
+    """Test that modules can be executed via python -m."""
+
+    def test_eab_module_executable(self):
+        """python -m eab --help should work."""
+        result = subprocess.run(
+            [sys.executable, "-m", "eab", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "Embedded Agent Bridge" in result.stdout or "usage:" in result.stdout
+
+    def test_eab_module_version(self):
+        """python -m eab --version should work."""
+        result = subprocess.run(
+            [sys.executable, "-m", "eab", "--version"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        # Version output goes to stdout with argparse
+        output = result.stdout + result.stderr
+        assert "1.0.0" in output or "embedded-agent-bridge" in output
+
+
+class TestPackageStructure:
+    """Test that the package structure is correct for installation."""
+
+    def test_pyproject_exists(self):
+        """pyproject.toml should exist at the repo root."""
+        repo_root = Path(__file__).parent.parent
+        pyproject = repo_root / "pyproject.toml"
+        assert pyproject.exists(), "pyproject.toml not found"
+
+    def test_pyproject_has_entry_points(self):
+        """pyproject.toml should define entry points."""
+        repo_root = Path(__file__).parent.parent
+        pyproject = repo_root / "pyproject.toml"
+        content = pyproject.read_text()
+
+        assert "[project.scripts]" in content
+        assert "eab = " in content
+        assert "eab-control = " in content
+
+    def test_control_module_exists(self):
+        """eab/control.py should exist."""
+        repo_root = Path(__file__).parent.parent
+        control_module = repo_root / "eab" / "control.py"
+        assert control_module.exists(), "eab/control.py not found"
+
+    def test_daemon_module_exists(self):
+        """eab/daemon.py should exist."""
+        repo_root = Path(__file__).parent.parent
+        daemon_module = repo_root / "eab" / "daemon.py"
+        assert daemon_module.exists(), "eab/daemon.py not found"
+
+    def test_control_has_main(self):
+        """eab.control should have a main() function."""
+        from eab import control
+        assert hasattr(control, "main")
+        assert callable(control.main)
+
+    def test_daemon_has_main(self):
+        """eab.daemon should have a main() function."""
+        from eab import daemon
+        assert hasattr(daemon, "main")
+        assert callable(daemon.main)


### PR DESCRIPTION
## Summary
- Created `pyproject.toml` with proper package metadata and entry points
- Converted eabctl to `eab/control.py` module for installability
- Updated `eab/daemon.py` with proper CLI signature (argv parameter, int return)
- Added `--version` flags to both CLI tools
- Created comprehensive test suite (18 tests, all passing)

## What this enables
- Clean installation: `uv pip install -e .`
- System-wide CLI commands: `eab` and `eab-control`
- Proper dependency management via pyproject.toml
- Better development workflow with editable installs

## Package Structure
```
embedded-agent-bridge/
├── pyproject.toml          # NEW: Package metadata and entry points
├── eab/
│   ├── __init__.py
│   ├── __main__.py         # UPDATED: Proper sys.exit pattern
│   ├── daemon.py           # UPDATED: main(argv) -> int, --version flag
│   ├── control.py          # NEW: Moved from eabctl, installable entry point
│   └── ...
└── tests/                  # NEW: Test directory
    ├── __init__.py
    └── test_cli_entry_points.py  # NEW: 18 tests for CLI functionality
```

## Entry Points
After installation, these commands become available system-wide:
- `eab --help` → daemon CLI
- `eab --version` → shows version
- `eab-control status` → control CLI
- `eab-control --version` → shows version

## Tests
All 18 tests pass, covering:
- Entry point function signatures
- CLI flags (--help, --version)
- Module execution (python -m eab)
- Package structure validation
- Argument parsing

## Backwards Compatibility
- Original `eabctl` and `eab-control` bash scripts remain unchanged
- All existing functionality preserved
- No breaking changes to the API

## Installation Example
```bash
cd embedded-agent-bridge
uv pip install -e .
eab --version
eab-control --version
```

## Test Plan
- [x] All 18 new tests pass
- [x] `python3 -m eab --help` works
- [x] `python3 -m eab --version` works
- [x] Entry points defined correctly in pyproject.toml
- [x] Package structure follows Python best practices
- [x] Backwards compatible with existing scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)