### PR TITLE
docs: update all docs for multi-platform scope

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Embedded Agent Bridge (EAB)
 
-> ESP32 serial communication daemon. ALWAYS use eabctl for ALL ESP32 operations.
+> Daemon and CLI bridging AI agents to embedded hardware (ESP32, STM32, nRF, NXP MCX). ALWAYS use eabctl for ALL hardware operations.
 
 ## CRITICAL: DO NOT USE THESE DIRECTLY
 - esptool
@@ -26,6 +26,10 @@ Flash firmware:
 
 Reset device:
     eabctl reset
+
+Fault analysis (Cortex-M crash decode):
+    eabctl fault-analyze --device NRF5340_XXAA_APP --json
+    eabctl fault-analyze --device MCXN947 --probe openocd --chip mcxn947 --json
 
 Send command:
     eabctl send "text"
@@ -74,3 +78,7 @@ Check /tmp/eab-session/events.jsonl for JSONL event records (pause/resume, flash
 
 When enabled, raw bytes are written to /tmp/eab-session/data.bin.
 Binary framing is **optional** and only applies when custom firmware is allowed (see PROTOCOL.md).
+
+## SUPPORTED HARDWARE
+
+ESP32 (serial/esptool), STM32 (ST-Link/st-flash), nRF5340 (J-Link/west flash), MCXN947 (OpenOCD/west flash), any Zephyr target with J-Link or OpenOCD.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "MIT"}
 authors = [
     {name = "Shane Mattner"}
 ]
-keywords = ["embedded", "serial", "esp32", "stm32", "debugging", "ai-agent"]
+keywords = ["embedded", "serial", "esp32", "stm32", "debugging", "ai-agent", "zephyr", "nrf", "nrf5340", "cortex-m", "fault-analysis", "rtt", "openocd", "jlink", "cmsis-dap"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -31,7 +31,7 @@ class TestDaemonEntryPoint:
         assert sig.parameters["argv"].default is None
         # And the annotation should be Optional (either old-style or new-style union)
         annotation_str = str(sig.parameters["argv"].annotation)
-        assert "None" in annotation_str and "list" in annotation_str
+        assert ("None" in annotation_str or "Optional" in annotation_str) and "list" in annotation_str
 
     def test_daemon_main_returns_int(self):
         """The main() function should return an int exit code."""


### PR DESCRIPTION
## Summary

- **README.md** — New architecture diagram (Serial + RTT + Fault paths), added features (RTT, fault analysis, debug probes, Zephyr), updated hardware table (nRF5340, MCXN947), marked 5 roadmap items complete, updated platform/dependency info
- **CLAUDE.md** — Multi-platform scope description, generalized agent rules beyond ESP32, added fault-analyze + Zephyr commands, hardware table, troubleshooting entries
- **AGENT_GUIDE.md + llms.txt** — Updated scope line, added fault-analyze/RTT workflows, hardware support table
- **SKILL.md (eab + eab-test)** — Updated frontmatter, chip tables, fault/RTT test sections, test count 115→341+
- **TESTING.md** — Added nRF5340/MCXN947 hardware rows, fault analysis/RTT/Zephyr E2E sections, updated test count
- **pyproject.toml** — Added 9 keywords (zephyr, nrf, cortex-m, fault-analysis, rtt, openocd, jlink, cmsis-dap)
- **test fix** — `test_daemon_main_accepts_argv` handles `Optional` annotation format (342 pass, 1 pre-existing)

Closes #55 (RTT support), Closes #60 (Zephyr RTOS support)

## E2E Hardware Verification

All tested on real hardware before PR:

| Test | Board | Result |
|------|-------|--------|
| Unit tests (342/343) | — | PASS |
| Fault analysis (J-Link) | nRF5340 DK | PASS — full register dump, backtrace, stacked PC |
| Fault analysis (OpenOCD) | FRDM-MCXN947 | PASS — CFSR/HFSR/BFAR/MMFAR decoded |
| RTT via JLinkBridge | nRF5340 DK | PASS — rtt.log (3.7KB), rtt.jsonl (4.3KB), rtt.csv (294B) |
| J-Link GDB Server | nRF5340 DK | PASS — connects, SWD 4MHz |
| Debug probe registry | — | PASS — jlink + openocd backends |
| Zephyr chip profiles | nrf5340/mcxn947/rp2040 | PASS — west flash commands, OpenOCD configs |
| Fault decoders | nrf5340/mcxn947 | PASS — CortexMDecoder, 7 GDB commands each |

## Test plan

- [x] `pytest tests/ eab/tests/` — 342 passed, 1 pre-existing failure
- [x] nRF5340 fault analysis via J-Link (real hardware)
- [x] MCXN947 fault analysis via OpenOCD/CMSIS-DAP (real hardware)
- [x] RTT start/stop/output files via JLinkBridge (real hardware)
- [x] Spot-check all 9 files for consistency
- [x] Verify GitHub issues #55 and #60 closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)