### PR TITLE
feat: Read ZEPHYR_BASE from CMakeCache for out-of-tree builds

### DIFF
--- a/eab/chips/zephyr.py
+++ b/eab/chips/zephyr.py
@@ -279,6 +279,12 @@ class ZephyrProfile(ChipProfile):
 
         Handles out-of-tree builds where the build dir is outside the Zephyr
         workspace (e.g., ``west build --build-dir /tmp/build-nrf5340``).
+
+        Args:
+            build_path: Path to the Zephyr build directory containing CMakeCache.txt.
+
+        Returns:
+            Path to ZEPHYR_BASE directory, or None if not found, unreadable, or invalid.
         """
         cmake_cache = build_path / "CMakeCache.txt"
         if not cmake_cache.exists():
@@ -290,7 +296,8 @@ class ZephyrProfile(ChipProfile):
                 zb = Path(match.group(1).strip())
                 if zb.is_dir():
                     return zb
-        except Exception:
+        except (OSError, UnicodeDecodeError):
+            # Silently fail — flash should proceed even if CMakeCache is unreadable
             pass
         return None
 

--- a/eab/tests/test_zephyr_profile.py
+++ b/eab/tests/test_zephyr_profile.py
@@ -450,6 +450,31 @@ def test_zephyr_read_zephyr_base_from_cmake_invalid_path():
         assert result is None
 
 
+def test_zephyr_read_zephyr_base_from_cmake_no_zephyr_base_line():
+    """Test _read_zephyr_base_from_cmake returns None when CMakeCache.txt has no ZEPHYR_BASE line."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        build_path = Path(tmpdir)
+        (build_path / "CMakeCache.txt").write_text(
+            "BOARD:STRING=nrf5340dk/nrf5340/cpuapp\n"
+            "CMAKE_BUILD_TYPE:STRING=Debug\n"
+        )
+        result = ZephyrProfile._read_zephyr_base_from_cmake(build_path)
+        assert result is None
+
+
+def test_zephyr_read_zephyr_base_from_cmake_unreadable(tmp_path):
+    """Test _read_zephyr_base_from_cmake returns None when CMakeCache.txt cannot be read."""
+    cmake_cache = tmp_path / "CMakeCache.txt"
+    cmake_cache.write_text("ZEPHYR_BASE:PATH=/some/path\n")
+    cmake_cache.chmod(0o000)
+
+    try:
+        result = ZephyrProfile._read_zephyr_base_from_cmake(tmp_path)
+        assert result is None
+    finally:
+        cmake_cache.chmod(0o644)
+
+
 def test_zephyr_board_defaults_class_var():
     """Test BOARD_DEFAULTS class variable contains expected entries."""
     assert "nrf5340" in ZephyrProfile.BOARD_DEFAULTS


### PR DESCRIPTION
## Summary
- When build dir is outside Zephyr workspace (e.g., `/tmp/build-nrf5340`), `_find_workspace` can't locate `.west/` by walking up
- Falls back to reading `ZEPHYR_BASE:PATH` from `CMakeCache.txt` in the build directory
- 4 new tests, all 42 pass

## Test plan
- [x] `eabctl flash` works without explicit ZEPHYR_BASE for out-of-tree builds
- [x] nRF5340 DK flashed successfully