### PR TITLE
Clear stale session files on eabctl start

### DIFF
--- a/eab/daemon.py
+++ b/eab/daemon.py
@@ -420,6 +420,10 @@ class SerialDaemon:
             port=self._reconnection._port_name,
             baud=self._baud,
         )
+        
+        # Reset pattern counts for fresh session
+        self._pattern_matcher.reset_counts()
+        
         self._status_manager.set_connection_state(ConnectionState.CONNECTED)
         self._status_manager.set_stream_state(
             enabled=self._stream_enabled,

--- a/eab/tests/test_daemon_cmds.py
+++ b/eab/tests/test_daemon_cmds.py
@@ -1,0 +1,301 @@
+"""Tests for daemon command functions (start, stop, pause, resume, diagnose)."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+
+# Add parent directory to path for imports (consistent with existing tests).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from eab.cli.daemon_cmds import cmd_start
+
+
+def test_cmd_start_clears_stale_session_files(tmp_path: Path):
+    """Test that cmd_start clears stale session files and writes placeholder status.
+    
+    This test verifies that when cmd_start() is called:
+    1. Stale session files with old data (high idle_seconds, stuck health status) are cleared
+    2. The placeholder status.json is written with 'starting' status
+    3. The daemon subprocess is spawned correctly
+    """
+    base_dir = tmp_path / "session"
+    base_dir.mkdir(parents=True)
+    
+    # Create stale session files with old data
+    stale_status = {
+        "session": {
+            "id": "old-session-123",
+            "started": "2023-01-01T00:00:00",
+            "uptime_seconds": 86400,
+        },
+        "connection": {
+            "port": "/dev/ttyUSB0",
+            "baud": 115200,
+            "status": "disconnected",
+            "reconnects": 42,
+        },
+        "counters": {
+            "lines_logged": 1000,
+            "bytes_received": 50000,
+            "commands_sent": 10,
+            "alerts_triggered": 5,
+        },
+        "health": {
+            "last_activity": "2023-01-01T12:00:00",
+            "idle_seconds": 3600,  # High idle time
+            "bytes_last_minute": 0,
+            "read_errors": 2,
+            "usb_disconnects": 1,
+            "status": "stuck",  # Stuck status
+        },
+        "patterns": {
+            "WATCHDOG": 15,
+            "BOOT": 20,
+        },
+        "stream": {
+            "enabled": False,
+            "active": False,
+        },
+        "last_updated": "2023-01-01T12:00:00",
+    }
+    
+    status_path = base_dir / "status.json"
+    status_path.write_text(json.dumps(stale_status, indent=2), encoding="utf-8")
+    
+    # Create other stale session files
+    (base_dir / "latest.log").write_text("old log data\n", encoding="utf-8")
+    (base_dir / "alerts.log").write_text("old alert\n", encoding="utf-8")
+    (base_dir / "events.jsonl").write_text('{"type":"old_event"}\n', encoding="utf-8")
+    (base_dir / "cmd.txt").write_text("old_command\n", encoding="utf-8")
+    (base_dir / "pause.txt").write_text("1234567890\n", encoding="utf-8")
+    (base_dir / "stream.json").write_text('{"enabled":true}\n', encoding="utf-8")
+    
+    # Verify stale files exist before cmd_start
+    assert status_path.exists()
+    assert (base_dir / "latest.log").exists()
+    
+    # Verify stale status has stuck health status and high idle_seconds
+    stale_data = json.loads(status_path.read_text(encoding="utf-8"))
+    assert stale_data["health"]["status"] == "stuck"
+    assert stale_data["health"]["idle_seconds"] == 3600
+    
+    # Mock subprocess.Popen to avoid actually starting a daemon
+    mock_proc = Mock()
+    mock_proc.pid = 12345
+    
+    with patch("eab.cli.daemon_cmds.subprocess.Popen", return_value=mock_proc) as mock_popen, \
+         patch("eab.cli.daemon_cmds.check_singleton", return_value=None), \
+         patch("eab.cli.daemon_cmds.cleanup_dead_locks"):
+        
+        # Call cmd_start
+        result = cmd_start(
+            base_dir=str(base_dir),
+            port="/dev/ttyUSB0",
+            baud=115200,
+            force=False,
+            json_mode=False,
+        )
+        
+        # Verify cmd_start returned success
+        assert result == 0
+        
+        # Verify subprocess.Popen was called to spawn daemon
+        assert mock_popen.called
+        popen_args = mock_popen.call_args
+        assert popen_args.kwargs["start_new_session"] is True
+        
+    # Verify placeholder status.json was written
+    assert status_path.exists()
+    new_status = json.loads(status_path.read_text(encoding="utf-8"))
+    
+    # Verify placeholder contains 'starting' status
+    assert new_status["health"]["status"] == "starting"
+    assert new_status["connection"]["status"] == "starting"
+    
+    # Verify old stale data is replaced (not present in placeholder)
+    assert "session" not in new_status or new_status.get("session") is None or new_status.get("session") == {}
+    assert "counters" not in new_status or new_status.get("counters") is None or new_status.get("counters") == {}
+    assert "patterns" not in new_status or new_status.get("patterns") is None or new_status.get("patterns") == {}
+    
+    # Verify idle_seconds and stuck status are not in the placeholder
+    assert new_status["health"].get("idle_seconds") is None or "idle_seconds" not in new_status["health"]
+
+
+def test_cmd_start_with_force_kills_existing_daemon(tmp_path: Path):
+    """Test that cmd_start with force=True kills existing daemon before starting."""
+    base_dir = tmp_path / "session"
+    base_dir.mkdir(parents=True)
+    
+    # Mock existing daemon
+    mock_existing = Mock()
+    mock_existing.is_alive = True
+    mock_existing.pid = 999
+    
+    mock_proc = Mock()
+    mock_proc.pid = 12345
+    
+    with patch("eab.cli.daemon_cmds.subprocess.Popen", return_value=mock_proc), \
+         patch("eab.cli.daemon_cmds.check_singleton", return_value=mock_existing), \
+         patch("eab.cli.daemon_cmds.kill_existing_daemon") as mock_kill, \
+         patch("eab.cli.daemon_cmds.cleanup_dead_locks"), \
+         patch("eab.cli.daemon_cmds.list_all_locks", return_value=[]):
+        
+        result = cmd_start(
+            base_dir=str(base_dir),
+            port="/dev/ttyUSB0",
+            baud=115200,
+            force=True,
+            json_mode=False,
+        )
+        
+        # Verify kill_existing_daemon was called
+        assert mock_kill.called
+        
+        # Verify cmd_start succeeded
+        assert result == 0
+
+
+def test_cmd_start_without_force_returns_error_if_daemon_running(tmp_path: Path):
+    """Test that cmd_start without force returns error if daemon already running."""
+    base_dir = tmp_path / "session"
+    base_dir.mkdir(parents=True)
+    
+    # Mock existing running daemon
+    mock_existing = Mock()
+    mock_existing.is_alive = True
+    mock_existing.pid = 999
+    
+    with patch("eab.cli.daemon_cmds.check_singleton", return_value=mock_existing), \
+         patch("eab.cli.daemon_cmds.subprocess.Popen") as mock_popen:
+        
+        result = cmd_start(
+            base_dir=str(base_dir),
+            port="/dev/ttyUSB0",
+            baud=115200,
+            force=False,
+            json_mode=False,
+        )
+        
+        # Verify cmd_start returned error code 1
+        assert result == 1
+        
+        # Verify subprocess.Popen was NOT called
+        assert not mock_popen.called
+
+
+def test_cmd_start_writes_placeholder_before_daemon_initializes(tmp_path: Path):
+    """Test that placeholder status.json is written immediately after spawning daemon.
+    
+    This prevents race conditions where eabctl status is called before daemon
+    has initialized its status.json file.
+    """
+    base_dir = tmp_path / "session"
+    base_dir.mkdir(parents=True)
+    
+    status_path = base_dir / "status.json"
+    
+    # Ensure status.json doesn't exist before cmd_start
+    assert not status_path.exists()
+    
+    mock_proc = Mock()
+    mock_proc.pid = 12345
+    
+    with patch("eab.cli.daemon_cmds.subprocess.Popen", return_value=mock_proc), \
+         patch("eab.cli.daemon_cmds.check_singleton", return_value=None), \
+         patch("eab.cli.daemon_cmds.cleanup_dead_locks"):
+        
+        result = cmd_start(
+            base_dir=str(base_dir),
+            port="/dev/ttyUSB0",
+            baud=115200,
+            force=False,
+            json_mode=False,
+        )
+        
+        assert result == 0
+    
+    # Verify status.json exists after cmd_start
+    assert status_path.exists()
+    
+    # Verify it contains placeholder data with 'starting' status
+    status = json.loads(status_path.read_text(encoding="utf-8"))
+    assert status["health"]["status"] == "starting"
+    assert status["connection"]["status"] == "starting"
+    
+    # Verify it's minimal (no stale counters, patterns, etc.)
+    assert len(status) == 2  # Only 'health' and 'connection'
+    assert len(status["health"]) == 1  # Only 'status'
+    assert len(status["connection"]) == 1  # Only 'status'
+
+
+def test_cmd_start_creates_base_dir_if_not_exists(tmp_path: Path):
+    """Test that cmd_start creates base_dir if it doesn't exist."""
+    base_dir = tmp_path / "nonexistent" / "session"
+    
+    # Verify base_dir doesn't exist
+    assert not base_dir.exists()
+    
+    mock_proc = Mock()
+    mock_proc.pid = 12345
+    
+    with patch("eab.cli.daemon_cmds.subprocess.Popen", return_value=mock_proc), \
+         patch("eab.cli.daemon_cmds.check_singleton", return_value=None), \
+         patch("eab.cli.daemon_cmds.cleanup_dead_locks"):
+        
+        result = cmd_start(
+            base_dir=str(base_dir),
+            port="/dev/ttyUSB0",
+            baud=115200,
+            force=False,
+            json_mode=False,
+        )
+        
+        assert result == 0
+    
+    # Verify base_dir was created
+    assert base_dir.exists()
+    assert base_dir.is_dir()
+    
+    # Verify status.json was written in the new directory
+    status_path = base_dir / "status.json"
+    assert status_path.exists()
+
+
+def test_cmd_start_json_mode_output(tmp_path: Path, capsys):
+    """Test that cmd_start with json_mode=True outputs valid JSON."""
+    base_dir = tmp_path / "session"
+    base_dir.mkdir(parents=True)
+    
+    mock_proc = Mock()
+    mock_proc.pid = 12345
+    
+    with patch("eab.cli.daemon_cmds.subprocess.Popen", return_value=mock_proc), \
+         patch("eab.cli.daemon_cmds.check_singleton", return_value=None), \
+         patch("eab.cli.daemon_cmds.cleanup_dead_locks"):
+        
+        result = cmd_start(
+            base_dir=str(base_dir),
+            port="/dev/ttyUSB0",
+            baud=115200,
+            force=False,
+            json_mode=True,
+        )
+        
+        assert result == 0
+    
+    # Verify JSON output
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    
+    assert output["schema_version"] == 1
+    assert output["started"] is True
+    assert output["pid"] == 12345
+    assert "timestamp" in output
+    assert "log_path" in output
+    assert "err_path" in output

--- a/eab/tests/test_pattern_reset_on_session.py
+++ b/eab/tests/test_pattern_reset_on_session.py
@@ -1,0 +1,390 @@
+"""
+Tests for pattern counter reset on fresh session start.
+
+Ensures that pattern counters in PatternMatcher and StatusManager are reset
+when a new session starts, preventing counts from persisting across sessions.
+"""
+
+import os
+import sys
+from datetime import datetime
+
+import pytest
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from eab.pattern_matcher import PatternMatcher
+from eab.status_manager import StatusManager
+from eab.mocks import MockFileSystem, MockClock
+
+
+class TestPatternMatcherResetCounts:
+    """Tests for PatternMatcher.reset_counts()."""
+
+    def test_reset_counts_clears_all_pattern_counts(self):
+        """reset_counts() should reset all pattern counts to zero."""
+        matcher = PatternMatcher(load_defaults=True)
+
+        # Trigger some pattern matches
+        matcher.check_line("ERROR: First error")
+        matcher.check_line("ERROR: Second error")
+        matcher.check_line("WATCHDOG: Task watchdog triggered")
+        matcher.check_line("BOOT: rst:0x10 (SW_CPU_RESET)")
+
+        # Verify counts are non-zero
+        counts_before = matcher.get_counts()
+        assert counts_before["ERROR"] >= 2
+        assert counts_before["WATCHDOG"] >= 1
+        assert counts_before["BOOT"] >= 1
+
+        # Reset counts
+        matcher.reset_counts()
+
+        # Verify all counts are zero
+        counts_after = matcher.get_counts()
+        for pattern_name, count in counts_after.items():
+            assert count == 0, f"Pattern '{pattern_name}' should be reset to 0, got {count}"
+
+    def test_reset_counts_with_custom_patterns(self):
+        """reset_counts() should work with custom patterns."""
+        matcher = PatternMatcher()
+        matcher.add_pattern("CUSTOM", "CUSTOM", is_regex=False)
+        matcher.add_pattern("ANOTHER", "ANOTHER", is_regex=False)
+
+        # Trigger matches
+        matcher.check_line("CUSTOM error occurred")
+        matcher.check_line("ANOTHER problem found")
+        matcher.check_line("CUSTOM issue detected")
+
+        # Verify counts
+        counts_before = matcher.get_counts()
+        assert counts_before["CUSTOM"] == 2
+        assert counts_before["ANOTHER"] == 1
+
+        # Reset
+        matcher.reset_counts()
+
+        # Verify reset
+        counts_after = matcher.get_counts()
+        assert counts_after["CUSTOM"] == 0
+        assert counts_after["ANOTHER"] == 0
+
+    def test_reset_counts_preserves_patterns(self):
+        """reset_counts() should not remove patterns, only reset their counts."""
+        matcher = PatternMatcher()
+        matcher.add_pattern("ERROR", "ERROR")
+        matcher.add_pattern("WARN", "WARN")
+
+        # Check some lines
+        matcher.check_line("ERROR: test")
+        matcher.check_line("WARN: test")
+
+        # Reset counts
+        matcher.reset_counts()
+
+        # Patterns should still exist
+        patterns = matcher.get_patterns()
+        assert "ERROR" in patterns
+        assert "WARN" in patterns
+
+        # Should still be able to match
+        matches = matcher.check_line("ERROR: another test")
+        assert len(matches) == 1
+        assert matches[0].pattern == "ERROR"
+
+        # Count should be 1 (not accumulated from before reset)
+        counts = matcher.get_counts()
+        assert counts["ERROR"] == 1
+
+    def test_reset_counts_on_empty_matcher(self):
+        """reset_counts() should work even with no patterns."""
+        matcher = PatternMatcher()
+        matcher.reset_counts()  # Should not raise
+
+        counts = matcher.get_counts()
+        assert counts == {}
+
+
+class TestStatusManagerResetCounts:
+    """Tests for StatusManager pattern count reset during start_session()."""
+
+    def test_start_session_resets_pattern_counts(self, tmp_path):
+        """start_session() should reset pattern_counts to empty dict."""
+        import json
+        
+        fs = MockFileSystem()
+        clock = MockClock(datetime(2025, 1, 1, 12, 0, 0))
+        status_path = tmp_path / "status.json"
+        status = StatusManager(
+            filesystem=fs,
+            clock=clock,
+            status_path=str(status_path),
+        )
+
+        # Start first session and record some alerts
+        status.start_session("session1", "/dev/ttyUSB0", 115200)
+        status.record_alert("ERROR")
+        status.record_alert("ERROR")
+        status.record_alert("WATCHDOG")
+        status.update()
+
+        # Verify pattern counts are tracked
+        status_data = json.loads(status_path.read_text(encoding="utf-8"))
+        assert status_data["patterns"]["ERROR"] == 2
+        assert status_data["patterns"]["WATCHDOG"] == 1
+
+        # Start a new session
+        status.start_session("session2", "/dev/ttyUSB0", 115200)
+        status.update()
+
+        # Verify pattern counts are reset
+        status_data = json.loads(status_path.read_text(encoding="utf-8"))
+        assert status_data["patterns"] == {}
+
+    def test_start_session_resets_other_counters(self, tmp_path):
+        """start_session() should reset all session-specific counters."""
+        import json
+        
+        fs = MockFileSystem()
+        clock = MockClock(datetime(2025, 1, 1, 12, 0, 0))
+        status_path = tmp_path / "status.json"
+        status = StatusManager(
+            filesystem=fs,
+            clock=clock,
+            status_path=str(status_path),
+        )
+
+        # Start first session and generate activity
+        status.start_session("session1", "/dev/ttyUSB0", 115200)
+        status.record_line()
+        status.record_line()
+        status.record_bytes(100)
+        status.record_command()
+        status.record_alert("ERROR")
+        status.update()
+
+        # Verify counters
+        status_data = json.loads(status_path.read_text(encoding="utf-8"))
+        assert status_data["counters"]["lines_logged"] == 2
+        assert status_data["counters"]["bytes_received"] == 100
+        assert status_data["counters"]["commands_sent"] == 1
+        assert status_data["counters"]["alerts_triggered"] == 1
+
+        # Start new session
+        status.start_session("session2", "/dev/ttyUSB0", 115200)
+        status.update()
+
+        # Verify all counters are reset
+        status_data = json.loads(status_path.read_text(encoding="utf-8"))
+        assert status_data["counters"]["lines_logged"] == 0
+        assert status_data["counters"]["bytes_received"] == 0
+        assert status_data["counters"]["commands_sent"] == 0
+        assert status_data["counters"]["alerts_triggered"] == 0
+        assert status_data["patterns"] == {}
+
+
+class TestDaemonPatternResetIntegration:
+    """Integration tests for daemon resetting pattern counts on session start."""
+
+    def test_daemon_resets_pattern_counts_on_start(self, tmp_path, monkeypatch):
+        """Daemon should call reset_counts() on PatternMatcher when starting a session."""
+        import eab.daemon as daemon_mod
+        from eab.mocks import MockSerialPort, MockClock, MockLogger
+        import eab.singleton
+        import eab.port_lock
+
+        # Isolate singleton and locks
+        monkeypatch.setattr(
+            eab.singleton.SingletonDaemon, "PID_FILE", str(tmp_path / "eab-daemon.pid")
+        )
+        monkeypatch.setattr(
+            eab.singleton.SingletonDaemon, "INFO_FILE", str(tmp_path / "eab-daemon.info")
+        )
+        monkeypatch.setattr(eab.port_lock.PortLock, "LOCK_DIR", str(tmp_path / "locks"))
+
+        # Avoid external tooling
+        monkeypatch.setattr(daemon_mod, "find_port_users", lambda _port: [])
+        monkeypatch.setattr(daemon_mod, "list_all_locks", lambda: [])
+
+        base_dir = tmp_path / "session"
+        port_path = tmp_path / "fake_serial_port"
+        port_path.write_text("", encoding="utf-8")
+
+        serial = MockSerialPort()
+        clock = MockClock()
+        logger = MockLogger()
+
+        daemon = daemon_mod.SerialDaemon(
+            port=str(port_path),
+            baud=115200,
+            base_dir=str(base_dir),
+            auto_detect=False,
+            serial_port=serial,
+            clock=clock,
+            logger=logger,
+        )
+
+        # Simulate some pattern matches before starting
+        daemon._pattern_matcher.check_line("ERROR: Pre-start error")
+        daemon._pattern_matcher.check_line("BOOT: rst:0x10")
+
+        # Verify counts before start
+        counts_before = daemon._pattern_matcher.get_counts()
+        assert counts_before["ERROR"] >= 1
+        assert counts_before["BOOT"] >= 1
+
+        # Start daemon (should reset counts)
+        assert daemon.start(force=True) is True
+
+        # Verify counts are reset after start
+        counts_after = daemon._pattern_matcher.get_counts()
+        for pattern_name, count in counts_after.items():
+            assert count == 0, f"Pattern '{pattern_name}' should be reset to 0 after daemon start, got {count}"
+
+    def test_daemon_pattern_counts_fresh_after_restart(self, tmp_path, monkeypatch):
+        """Pattern counts should be fresh when daemon is stopped and restarted."""
+        import eab.daemon as daemon_mod
+        from eab.mocks import MockSerialPort, MockClock, MockLogger
+        import eab.singleton
+        import eab.port_lock
+
+        # Isolate singleton and locks
+        monkeypatch.setattr(
+            eab.singleton.SingletonDaemon, "PID_FILE", str(tmp_path / "eab-daemon.pid")
+        )
+        monkeypatch.setattr(
+            eab.singleton.SingletonDaemon, "INFO_FILE", str(tmp_path / "eab-daemon.info")
+        )
+        monkeypatch.setattr(eab.port_lock.PortLock, "LOCK_DIR", str(tmp_path / "locks"))
+
+        # Avoid external tooling
+        monkeypatch.setattr(daemon_mod, "find_port_users", lambda _port: [])
+        monkeypatch.setattr(daemon_mod, "list_all_locks", lambda: [])
+
+        base_dir = tmp_path / "session"
+        port_path = tmp_path / "fake_serial_port"
+        port_path.write_text("", encoding="utf-8")
+
+        # First daemon instance
+        serial1 = MockSerialPort()
+        clock1 = MockClock()
+        logger1 = MockLogger()
+
+        daemon1 = daemon_mod.SerialDaemon(
+            port=str(port_path),
+            baud=115200,
+            base_dir=str(base_dir),
+            auto_detect=False,
+            serial_port=serial1,
+            clock=clock1,
+            logger=logger1,
+        )
+
+        # Start first daemon and generate some pattern matches
+        assert daemon1.start(force=True) is True
+        daemon1._process_line("ERROR: First daemon error")
+        daemon1._process_line("WATCHDOG: Task watchdog triggered")
+        daemon1._process_line("ERROR: Another error")
+
+        # Verify counts
+        counts1 = daemon1._pattern_matcher.get_counts()
+        assert counts1["ERROR"] >= 2
+        assert counts1["WATCHDOG"] >= 1
+
+        # Stop first daemon
+        daemon1.stop()
+
+        # Second daemon instance (simulating restart)
+        serial2 = MockSerialPort()
+        clock2 = MockClock()
+        logger2 = MockLogger()
+
+        daemon2 = daemon_mod.SerialDaemon(
+            port=str(port_path),
+            baud=115200,
+            base_dir=str(base_dir),
+            auto_detect=False,
+            serial_port=serial2,
+            clock=clock2,
+            logger=logger2,
+        )
+
+        # Start second daemon
+        assert daemon2.start(force=True) is True
+
+        # Verify counts are fresh (all zero)
+        counts2 = daemon2._pattern_matcher.get_counts()
+        for pattern_name, count in counts2.items():
+            assert count == 0, f"Pattern '{pattern_name}' should be 0 in fresh session, got {count}"
+
+        # Process new lines
+        daemon2._process_line("ERROR: Second daemon error")
+
+        # Verify only new counts
+        counts3 = daemon2._pattern_matcher.get_counts()
+        assert counts3["ERROR"] >= 1  # Only the new error
+        assert counts3["WATCHDOG"] == 0  # Should not have old watchdog count
+
+        daemon2.stop()
+
+    def test_status_json_patterns_empty_after_daemon_start(self, tmp_path, monkeypatch):
+        """status.json patterns field should be empty after daemon start."""
+        import eab.daemon as daemon_mod
+        from eab.mocks import MockSerialPort, MockClock, MockLogger
+        import eab.singleton
+        import eab.port_lock
+        import json
+
+        # Isolate singleton and locks
+        monkeypatch.setattr(
+            eab.singleton.SingletonDaemon, "PID_FILE", str(tmp_path / "eab-daemon.pid")
+        )
+        monkeypatch.setattr(
+            eab.singleton.SingletonDaemon, "INFO_FILE", str(tmp_path / "eab-daemon.info")
+        )
+        monkeypatch.setattr(eab.port_lock.PortLock, "LOCK_DIR", str(tmp_path / "locks"))
+
+        # Avoid external tooling
+        monkeypatch.setattr(daemon_mod, "find_port_users", lambda _port: [])
+        monkeypatch.setattr(daemon_mod, "list_all_locks", lambda: [])
+
+        base_dir = tmp_path / "session"
+        port_path = tmp_path / "fake_serial_port"
+        port_path.write_text("", encoding="utf-8")
+
+        serial = MockSerialPort()
+        clock = MockClock()
+        logger = MockLogger()
+
+        daemon = daemon_mod.SerialDaemon(
+            port=str(port_path),
+            baud=115200,
+            base_dir=str(base_dir),
+            auto_detect=False,
+            serial_port=serial,
+            clock=clock,
+            logger=logger,
+        )
+
+        # Start daemon
+        assert daemon.start(force=True) is True
+
+        # Check status.json
+        status_path = base_dir / "status.json"
+        assert status_path.exists()
+
+        status_data = json.loads(status_path.read_text(encoding="utf-8"))
+        assert status_data["patterns"] == {}, "Patterns should be empty dict at session start"
+
+        # Process some lines with patterns
+        daemon._process_line("ERROR: Test error")
+        daemon._process_line("BOOT: rst:0x10")
+        daemon._status_manager.update()
+
+        # Check status.json again
+        status_data = json.loads(status_path.read_text(encoding="utf-8"))
+        assert status_data["patterns"]["ERROR"] >= 1
+        assert status_data["patterns"]["BOOT"] >= 1
+
+        daemon.stop()

--- a/tests/test_cli_daemon_cmds.py
+++ b/tests/test_cli_daemon_cmds.py
@@ -1,0 +1,373 @@
+"""
+Tests for daemon command functions in eab.cli.daemon_cmds.
+
+Verifies session file cleanup helpers and other daemon management utilities.
+"""
+
+from __future__ import annotations
+
+import os
+import json
+import pytest
+
+
+class TestClearSessionFiles:
+    """Tests for _clear_session_files helper function."""
+
+    def test_clear_all_files_when_present(self, tmp_path):
+        """Should remove all session files when they exist."""
+        from eab.cli.daemon_cmds import _clear_session_files
+
+        # Create all session files with some content
+        status_path = tmp_path / "status.json"
+        alerts_path = tmp_path / "alerts.log"
+        events_path = tmp_path / "events.jsonl"
+
+        status_path.write_text(json.dumps({"status": "running"}))
+        alerts_path.write_text("Alert 1\nAlert 2\n")
+        events_path.write_text('{"type": "test"}\n')
+
+        # Verify files exist
+        assert status_path.exists()
+        assert alerts_path.exists()
+        assert events_path.exists()
+
+        # Clear session files
+        _clear_session_files(str(tmp_path))
+
+        # Verify files are removed
+        assert not status_path.exists()
+        assert not alerts_path.exists()
+        assert not events_path.exists()
+
+    def test_clear_when_files_missing(self, tmp_path):
+        """Should handle missing files gracefully without raising errors."""
+        from eab.cli.daemon_cmds import _clear_session_files
+
+        # Don't create any files - just call the function
+        # This should not raise FileNotFoundError
+        _clear_session_files(str(tmp_path))
+
+        # No files should exist
+        assert not (tmp_path / "status.json").exists()
+        assert not (tmp_path / "alerts.log").exists()
+        assert not (tmp_path / "events.jsonl").exists()
+
+    def test_clear_partial_files(self, tmp_path):
+        """Should handle case where only some files exist."""
+        from eab.cli.daemon_cmds import _clear_session_files
+
+        # Create only some files
+        status_path = tmp_path / "status.json"
+        events_path = tmp_path / "events.jsonl"
+
+        status_path.write_text(json.dumps({"status": "test"}))
+        events_path.write_text('{"type": "event"}\n')
+
+        # alerts.log does not exist
+        assert status_path.exists()
+        assert not (tmp_path / "alerts.log").exists()
+        assert events_path.exists()
+
+        # Clear session files
+        _clear_session_files(str(tmp_path))
+
+        # All should be gone or remain non-existent
+        assert not status_path.exists()
+        assert not (tmp_path / "alerts.log").exists()
+        assert not events_path.exists()
+
+    def test_clear_does_not_affect_other_files(self, tmp_path):
+        """Should only remove specific session files, leaving others intact."""
+        from eab.cli.daemon_cmds import _clear_session_files
+
+        # Create session files
+        status_path = tmp_path / "status.json"
+        alerts_path = tmp_path / "alerts.log"
+        events_path = tmp_path / "events.jsonl"
+
+        status_path.write_text(json.dumps({"status": "running"}))
+        alerts_path.write_text("Alert\n")
+        events_path.write_text('{"type": "test"}\n')
+
+        # Create other files that should not be affected
+        other_file = tmp_path / "other.txt"
+        cmd_file = tmp_path / "cmd.txt"
+        pause_file = tmp_path / "pause.txt"
+
+        other_file.write_text("keep me")
+        cmd_file.write_text("command")
+        pause_file.write_text("1234567890")
+
+        # Clear session files
+        _clear_session_files(str(tmp_path))
+
+        # Session files removed
+        assert not status_path.exists()
+        assert not alerts_path.exists()
+        assert not events_path.exists()
+
+        # Other files preserved
+        assert other_file.exists()
+        assert other_file.read_text() == "keep me"
+        assert cmd_file.exists()
+        assert cmd_file.read_text() == "command"
+        assert pause_file.exists()
+        assert pause_file.read_text() == "1234567890"
+
+    def test_clear_empty_directory(self, tmp_path):
+        """Should handle empty directory without errors."""
+        from eab.cli.daemon_cmds import _clear_session_files
+
+        # Empty directory
+        assert len(list(tmp_path.iterdir())) == 0
+
+        # Should not raise any errors
+        _clear_session_files(str(tmp_path))
+
+        # Directory should still be empty
+        assert len(list(tmp_path.iterdir())) == 0
+
+    def test_clear_nonexistent_directory(self):
+        """Should handle non-existent directory path."""
+        from eab.cli.daemon_cmds import _clear_session_files
+
+        # This directory doesn't exist
+        nonexistent = "/tmp/eab-test-nonexistent-dir-12345"
+        assert not os.path.exists(nonexistent)
+
+        # Should not raise errors (FileNotFoundError is caught)
+        _clear_session_files(nonexistent)
+
+    def test_clear_files_with_content(self, tmp_path):
+        """Should remove files regardless of content size."""
+        from eab.cli.daemon_cmds import _clear_session_files
+
+        # Create files with varying content sizes
+        status_path = tmp_path / "status.json"
+        alerts_path = tmp_path / "alerts.log"
+        events_path = tmp_path / "events.jsonl"
+
+        # Large status file
+        status_data = {"test": "x" * 10000}
+        status_path.write_text(json.dumps(status_data))
+
+        # Many alerts
+        alerts_path.write_text("Alert\n" * 1000)
+
+        # Many events
+        events_path.write_text('{"type": "event"}\n' * 500)
+
+        # Verify files have content
+        assert status_path.stat().st_size > 10000
+        assert alerts_path.stat().st_size > 5000
+        assert events_path.stat().st_size > 1000
+
+        # Clear session files
+        _clear_session_files(str(tmp_path))
+
+        # All removed
+        assert not status_path.exists()
+        assert not alerts_path.exists()
+        assert not events_path.exists()
+
+
+class TestCmdStartSessionCleanup:
+    """Tests verifying cmd_start() clears session files before starting daemon."""
+
+    def test_cmd_start_clears_session_files(self, tmp_path, monkeypatch):
+        """cmd_start should call _clear_session_files before spawning daemon."""
+        from eab.cli.daemon_cmds import cmd_start
+        import subprocess
+        
+        # Create stale session files
+        status_path = tmp_path / "status.json"
+        alerts_path = tmp_path / "alerts.log"
+        events_path = tmp_path / "events.jsonl"
+        
+        status_path.write_text(json.dumps({"connection": {"status": "stale"}}))
+        alerts_path.write_text("Old alert\n")
+        events_path.write_text('{"type": "old_event"}\n')
+        
+        assert status_path.exists()
+        assert alerts_path.exists()
+        assert events_path.exists()
+        
+        # Mock subprocess.Popen to prevent actually spawning daemon
+        popen_called = []
+        class MockPopen:
+            def __init__(self, *args, **kwargs):
+                popen_called.append((args, kwargs))
+                self.pid = 12345
+        
+        # Mock check_singleton to return None (no existing daemon)
+        def mock_check_singleton():
+            return None
+        
+        monkeypatch.setattr(subprocess, "Popen", MockPopen)
+        monkeypatch.setattr("eab.cli.daemon_cmds.check_singleton", mock_check_singleton)
+        
+        # Mock cleanup_dead_locks to do nothing
+        monkeypatch.setattr("eab.cli.daemon_cmds.cleanup_dead_locks", lambda: None)
+        
+        # Mock file operations for log files
+        import builtins
+        original_open = builtins.open
+        def mock_open(path, *args, **kwargs):
+            if path in ["/tmp/eab-daemon.log", "/tmp/eab-daemon.err"]:
+                import io
+                return io.StringIO()
+            return original_open(path, *args, **kwargs)
+        
+        monkeypatch.setattr(builtins, "open", mock_open)
+        
+        # Call cmd_start
+        result = cmd_start(
+            base_dir=str(tmp_path),
+            port="auto",
+            baud=115200,
+            force=False,
+            json_mode=True
+        )
+        
+        # Should succeed
+        assert result == 0
+        assert len(popen_called) == 1
+        
+        # alerts.log and events.jsonl should be cleared and not recreated
+        assert not alerts_path.exists()
+        assert not events_path.exists()
+        
+        # status.json is recreated with placeholder content after clearing
+        assert status_path.exists()
+        status_data = json.loads(status_path.read_text())
+        # Should have fresh placeholder content, not the old stale content
+        assert status_data.get("health", {}).get("status") == "starting"
+        assert status_data.get("connection", {}).get("status") == "starting"
+        assert "stale" not in status_path.read_text()
+
+    def test_cmd_start_with_force_clears_session_files(self, tmp_path, monkeypatch):
+        """cmd_start with --force should clear session files after killing daemon."""
+        from eab.cli.daemon_cmds import cmd_start
+        import subprocess
+        
+        # Create stale session files
+        status_path = tmp_path / "status.json"
+        alerts_path = tmp_path / "alerts.log"
+        events_path = tmp_path / "events.jsonl"
+        
+        status_path.write_text(json.dumps({"pid": 999}))
+        alerts_path.write_text("Stale alert\n")
+        events_path.write_text('{"type": "stale"}\n')
+        
+        # Mock an existing daemon
+        class MockExisting:
+            def __init__(self):
+                self.pid = 999
+                self.is_alive = True
+        
+        def mock_check_singleton():
+            return MockExisting()
+        
+        # Mock killing daemon
+        def mock_kill_existing_daemon():
+            return True
+        
+        # Mock list_all_locks to return empty (no port locks)
+        def mock_list_all_locks():
+            return []
+        
+        # Mock cleanup_dead_locks
+        def mock_cleanup_dead_locks():
+            pass
+        
+        # Mock subprocess.Popen
+        class MockPopen:
+            def __init__(self, *args, **kwargs):
+                self.pid = 12345
+        
+        monkeypatch.setattr("eab.cli.daemon_cmds.check_singleton", mock_check_singleton)
+        monkeypatch.setattr("eab.cli.daemon_cmds.kill_existing_daemon", mock_kill_existing_daemon)
+        monkeypatch.setattr("eab.cli.daemon_cmds.list_all_locks", mock_list_all_locks)
+        monkeypatch.setattr("eab.cli.daemon_cmds.cleanup_dead_locks", mock_cleanup_dead_locks)
+        monkeypatch.setattr(subprocess, "Popen", MockPopen)
+        
+        # Mock file operations
+        import builtins
+        original_open = builtins.open
+        def mock_open(path, *args, **kwargs):
+            if path in ["/tmp/eab-daemon.log", "/tmp/eab-daemon.err"]:
+                import io
+                return io.StringIO()
+            return original_open(path, *args, **kwargs)
+        
+        monkeypatch.setattr(builtins, "open", mock_open)
+        
+        # Call cmd_start with force=True
+        result = cmd_start(
+            base_dir=str(tmp_path),
+            port="auto",
+            baud=115200,
+            force=True,
+            json_mode=True
+        )
+        
+        # Should succeed
+        assert result == 0
+        
+        # alerts.log and events.jsonl should be cleared and not recreated
+        assert not alerts_path.exists()
+        assert not events_path.exists()
+        
+        # status.json is recreated with placeholder content after clearing
+        assert status_path.exists()
+        status_data = json.loads(status_path.read_text())
+        # Should have fresh placeholder content, not the old stale content
+        assert status_data.get("health", {}).get("status") == "starting"
+        assert status_data.get("connection", {}).get("status") == "starting"
+        # Old content should be gone
+        assert status_data.get("pid") != 999
+
+    def test_cmd_start_early_return_does_not_clear_files(self, tmp_path, monkeypatch):
+        """cmd_start should NOT clear files when returning early (daemon already running)."""
+        from eab.cli.daemon_cmds import cmd_start
+        
+        # Create existing session files
+        status_path = tmp_path / "status.json"
+        alerts_path = tmp_path / "alerts.log"
+        events_path = tmp_path / "events.jsonl"
+        
+        status_path.write_text(json.dumps({"pid": 999, "running": True}))
+        alerts_path.write_text("Current alert\n")
+        events_path.write_text('{"type": "current"}\n')
+        
+        # Mock an existing daemon
+        class MockExisting:
+            def __init__(self):
+                self.pid = 999
+                self.is_alive = True
+        
+        def mock_check_singleton():
+            return MockExisting()
+        
+        monkeypatch.setattr("eab.cli.daemon_cmds.check_singleton", mock_check_singleton)
+        
+        # Call cmd_start with force=False (should return early)
+        result = cmd_start(
+            base_dir=str(tmp_path),
+            port="auto",
+            baud=115200,
+            force=False,
+            json_mode=True
+        )
+        
+        # Should return error code (daemon already running)
+        assert result == 1
+        
+        # Session files should NOT be cleared (daemon is still running)
+        assert status_path.exists()
+        assert alerts_path.exists()
+        assert events_path.exists()
+        assert status_path.read_text() == json.dumps({"pid": 999, "running": True})
+        assert alerts_path.read_text() == "Current alert\n"
+        assert events_path.read_text() == '{"type": "current"}\n'


### PR DESCRIPTION
## Summary
- Add `_clear_session_files()` helper to remove stale status.json, alerts.log, events.jsonl on start
- Write placeholder status.json with "starting" state during startup race window
- Reset pattern matcher counts on fresh session start

Closes #86

## Test plan
- [x] 16 tests covering session cleanup, placeholder writing, and status manager
- [x] All existing tests pass