### PR TITLE
refactor: extract process_utils and file_utils from duplicated code

### DIFF
--- a/eab/file_utils.py
+++ b/eab/file_utils.py
@@ -1,0 +1,66 @@
+"""Shared file I/O utilities for EAB.
+
+Extracted from duplicated patterns in jlink_bridge, openocd_bridge, and others.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Optional, Union
+
+
+def read_json_file(path: Union[str, Path]) -> Optional[dict]:
+    """Read a JSON file and return its contents as a dict.
+
+    Returns ``None`` if the file is missing, unreadable, or not valid JSON.
+    """
+    p = Path(path)
+    if not p.exists():
+        return None
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def write_json_file(path: Union[str, Path], data: dict) -> None:
+    """Atomically write *data* as JSON to *path*.
+
+    Writes to a temporary file in the same directory and renames, so
+    readers never see a half-written file.
+    """
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(p.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+        os.replace(tmp, str(p))
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def read_text_safe(path: Union[str, Path]) -> str:
+    """Read text from *path*, returning an empty string on any error."""
+    try:
+        return Path(path).read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+def tail_file(path: Union[str, Path], n: int = 20) -> list[str]:
+    """Return the last *n* lines from *path*.
+
+    Returns an empty list if the file is missing or unreadable.
+    """
+    text = read_text_safe(path)
+    if not text:
+        return []
+    return text.splitlines()[-n:]

--- a/eab/jlink_bridge.py
+++ b/eab/jlink_bridge.py
@@ -11,27 +11,19 @@ JLinkBridge is the unified facade. RTT logic lives in jlink_rtt.py.
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import os
-import signal
 import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Optional
 
+from .file_utils import read_json_file, write_json_file, tail_file
 from .jlink_rtt import JLinkRTTManager, JLinkRTTStatus
+from .process_utils import pid_alive, read_pid_file, cleanup_pid_file, stop_process_graceful, popen_is_alive
 
 logger = logging.getLogger(__name__)
-
-
-def _pid_alive(pid: int) -> bool:
-    try:
-        os.kill(pid, 0)
-        return True
-    except OSError:
-        return False
 
 
 @dataclass(frozen=True)
@@ -138,14 +130,14 @@ class JLinkBridge:
     # =========================================================================
 
     def swo_status(self) -> JLinkSWOStatus:
-        pid = self._read_pid(self.swo_pid_path)
-        running = bool(pid) and _pid_alive(pid)
+        pid = read_pid_file(self.swo_pid_path)
+        running = bool(pid) and pid_alive(pid)
         if pid and not running:
-            self._cleanup_pid(self.swo_pid_path)
+            cleanup_pid_file(self.swo_pid_path)
             pid = None
 
         device = None
-        status_data = self._read_status_file(self.swo_status_path)
+        status_data = read_json_file(self.swo_status_path)
         if status_data:
             device = status_data.get("device")
 
@@ -210,7 +202,7 @@ class JLinkBridge:
             device=None,
             log_path=str(self.swo_log_path),
         )
-        self._write_status_file(self.swo_status_path, {
+        write_json_file(self.swo_status_path, {
             "running": False, "pid": None,
         })
         return status
@@ -220,15 +212,15 @@ class JLinkBridge:
     # =========================================================================
 
     def gdb_status(self) -> JLinkGDBStatus:
-        pid = self._read_pid(self.gdb_pid_path)
-        running = bool(pid) and _pid_alive(pid)
+        pid = read_pid_file(self.gdb_pid_path)
+        running = bool(pid) and pid_alive(pid)
         if pid and not running:
-            self._cleanup_pid(self.gdb_pid_path)
+            cleanup_pid_file(self.gdb_pid_path)
             pid = None
 
         device = None
         port = 2331
-        status_data = self._read_status_file(self.gdb_status_path)
+        status_data = read_json_file(self.gdb_status_path)
         if status_data:
             device = status_data.get("device")
             port = status_data.get("port", 2331)
@@ -305,7 +297,7 @@ class JLinkBridge:
             pid=None,
             device=None,
         )
-        self._write_status_file(self.gdb_status_path, {
+        write_json_file(self.gdb_status_path, {
             "running": False, "pid": None,
         })
         return status
@@ -353,16 +345,13 @@ class JLinkBridge:
         pid_path.write_text(str(proc.pid))
 
         time.sleep(0.5)
-        alive = _pid_alive(proc.pid) and (proc.poll() is None)
+        alive = pid_alive(proc.pid) and popen_is_alive(proc)
         last_error: Optional[str] = None
 
         if not alive:
-            try:
-                err_lines = err_path.read_text(encoding="utf-8", errors="replace").splitlines()[-20:]
-                last_error = "\n".join(err_lines).strip() or None
-            except Exception:
-                last_error = None
-            self._cleanup_pid(pid_path)
+            err_lines = tail_file(err_path, 20)
+            last_error = "\n".join(err_lines).strip() or None
+            cleanup_pid_file(pid_path)
 
         status = status_factory(alive, proc.pid if alive else None, last_error)
 
@@ -373,61 +362,16 @@ class JLinkBridge:
             "last_error": last_error,
             "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime()),
         }
-        self._write_status_file(status_path, payload)
+        write_json_file(status_path, payload)
 
         return status
 
     def _stop_process(self, pid_path: Path, timeout_s: float = 5.0) -> None:
         """Generic background process stopper."""
-        pid = self._read_pid(pid_path)
-        if not pid or not _pid_alive(pid):
-            self._cleanup_pid(pid_path)
+        pid = read_pid_file(pid_path)
+        if not pid or not pid_alive(pid):
+            cleanup_pid_file(pid_path)
             return
 
-        try:
-            os.kill(pid, signal.SIGTERM)
-        except OSError:
-            pass
-
-        deadline = time.time() + timeout_s
-        while time.time() < deadline:
-            if not _pid_alive(pid):
-                break
-            time.sleep(0.1)
-
-        if _pid_alive(pid):
-            try:
-                os.kill(pid, signal.SIGKILL)
-            except OSError:
-                pass
-
-        self._cleanup_pid(pid_path)
-
-    def _read_pid(self, path: Path) -> Optional[int]:
-        """Read PID from a file, return None if missing or invalid."""
-        if not path.exists():
-            return None
-        try:
-            return int(path.read_text().strip())
-        except (ValueError, OSError):
-            return None
-
-    def _cleanup_pid(self, path: Path) -> None:
-        """Remove a PID file if it exists."""
-        try:
-            path.unlink(missing_ok=True)
-        except OSError:
-            pass
-
-    def _read_status_file(self, path: Path) -> Optional[dict]:
-        """Read JSON status file, return None if missing or invalid."""
-        if not path.exists():
-            return None
-        try:
-            return json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            return None
-
-    def _write_status_file(self, path: Path, data: dict) -> None:
-        """Write JSON status file."""
-        path.write_text(json.dumps(data, indent=2, sort_keys=True))
+        stop_process_graceful(pid, timeout_s)
+        cleanup_pid_file(pid_path)

--- a/eab/process_utils.py
+++ b/eab/process_utils.py
@@ -1,0 +1,88 @@
+"""Shared process-management utilities for EAB.
+
+Extracted from duplicated patterns in jlink_bridge, openocd_bridge,
+debug_probes/openocd, and singleton.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Optional, Union
+
+
+def pid_alive(pid: int) -> bool:
+    """Check if a process is alive via ``os.kill(pid, 0)``.
+
+    Returns ``True`` if the process exists (even if we lack permission to
+    signal it), ``False`` otherwise.
+    """
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Can't signal it, but it exists.
+        return True
+    except OSError as exc:
+        if getattr(exc, "errno", None) == errno.EPERM:
+            return True
+        return False
+
+
+def read_pid_file(path: Union[str, Path]) -> Optional[int]:
+    """Read a PID from *path*, returning ``None`` on any error."""
+    p = Path(path)
+    if not p.exists():
+        return None
+    try:
+        return int(p.read_text().strip())
+    except (ValueError, OSError):
+        return None
+
+
+def cleanup_pid_file(path: Union[str, Path]) -> None:
+    """Remove a PID file if it exists (ignoring errors)."""
+    try:
+        Path(path).unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def stop_process_graceful(pid: int, timeout_s: float = 5.0) -> bool:
+    """Send SIGTERM, wait up to *timeout_s*, then SIGKILL if still alive.
+
+    Returns ``True`` if the process is no longer alive after the call.
+    """
+    if not pid_alive(pid):
+        return True
+
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError:
+        return True
+
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if not pid_alive(pid):
+            return True
+        time.sleep(0.1)
+
+    # Force-kill
+    try:
+        os.kill(pid, signal.SIGKILL)
+        time.sleep(0.5)
+    except OSError:
+        pass
+
+    return not pid_alive(pid)
+
+
+def popen_is_alive(proc: subprocess.Popen) -> bool:
+    """Check if a :class:`subprocess.Popen` process is still running."""
+    return proc.poll() is None

--- a/eab/tests/test_openocd_bridge.py
+++ b/eab/tests/test_openocd_bridge.py
@@ -24,7 +24,7 @@ def test_openocd_start_writes_cfg_and_status(tmp_path: Path, monkeypatch: pytest
 
     # Pretend process is alive.
     monkeypatch.setattr("eab.openocd_bridge.subprocess.Popen", fake_popen)
-    monkeypatch.setattr("eab.openocd_bridge._pid_alive", lambda pid: True)
+    monkeypatch.setattr("eab.openocd_bridge.pid_alive", lambda pid: True)
 
     st = bridge.start(chip="esp32s3", vid="0x303a", pid="0x1001")
     assert st.running is True
@@ -42,7 +42,7 @@ def test_openocd_start_cleans_pid_on_fast_failure(tmp_path: Path, monkeypatch: p
         return _Proc(23456, alive=False)
 
     monkeypatch.setattr("eab.openocd_bridge.subprocess.Popen", fake_popen)
-    monkeypatch.setattr("eab.openocd_bridge._pid_alive", lambda pid: False)
+    monkeypatch.setattr("eab.openocd_bridge.pid_alive", lambda pid: False)
 
     st = bridge.start()
     assert st.running is False

--- a/eab/tests/test_plotter.py
+++ b/eab/tests/test_plotter.py
@@ -275,7 +275,7 @@ class TestJLinkBridgeFdLeak:
             return FakeProc()
 
         monkeypatch.setattr("eab.jlink_bridge.subprocess.Popen", fake_popen)
-        monkeypatch.setattr("eab.jlink_bridge._pid_alive", lambda pid: True)
+        monkeypatch.setattr("eab.jlink_bridge.pid_alive", lambda pid: True)
         monkeypatch.setattr("builtins.open", lambda *a, **kw: TrackingFile(*a, **kw))
 
         bridge._start_process(

--- a/tests/test_debug_probes.py
+++ b/tests/test_debug_probes.py
@@ -139,7 +139,7 @@ class TestOpenOCDProbe:
         assert isinstance(probe, DebugProbeABC)
 
     @patch("eab.debug_probes.openocd.subprocess.Popen")
-    @patch("eab.debug_probes.openocd._pid_alive", return_value=True)
+    @patch("eab.debug_probes.openocd.pid_alive", return_value=True)
     def test_start_builds_cmd(self, mock_alive, mock_popen, tmp_path):
         """start_gdb_server() should build OpenOCD command with config."""
         mock_proc = MagicMock()


### PR DESCRIPTION
## Summary
- Created `eab/process_utils.py` (5 functions: pid_alive, read_pid_file, cleanup_pid_file, stop_process_graceful, popen_is_alive)
- Created `eab/file_utils.py` (4 functions: read_json_file, write_json_file, read_text_safe, tail_file)
- Updated 4 consumers: jlink_bridge.py, openocd_bridge.py, debug_probes/openocd.py, singleton.py
- Consolidated 5 copies of pid_alive, 4 copies of SIGTERM/SIGKILL logic, 3 copies of JSON I/O

## Test plan
- [x] 1077 tests pass, 0 new failures
- [x] Updated mock targets in 4 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)