### PR TITLE
fix: regression test silently exits on first pass

### DIFF
--- a/tests/regression_test.sh
+++ b/tests/regression_test.sh
@@ -20,12 +20,12 @@ FAILED_TESTS=()
 # Helper functions
 pass() {
     echo -e "${GREEN}✓${NC} $1"
-    ((TESTS_PASSED++))
+    ((TESTS_PASSED++)) || true
 }
 
 fail() {
     echo -e "${RED}✗${NC} $1"
-    ((TESTS_FAILED++))
+    ((TESTS_FAILED++)) || true
     FAILED_TESTS+=("$1")
 }
 


### PR DESCRIPTION
## Summary
- Fix `((TESTS_PASSED++))` returning exit code 1 when incrementing from 0 (bash arithmetic quirk)
- `set -e` at top of script kills it silently after first `pass()` call
- Add `|| true` to both `pass()` and `fail()` counter increments

## Context
The regression test script (`tests/regression_test.sh`) appeared to work but silently exited after detecting hardware. Only the J-Link detection pass was counted before the script died.

## Test plan
- [x] Ran full regression suite: 15/15 passed, 43 unit tests passed
- [x] All 8 test sections complete (imports, unit tests, daemon, serial, flash, debug, profile, CLI)
- [x] Tested on nRF5340 DK with J-Link + 5 USB serial devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)