### PR TITLE
feat: add .agent/ folder for multi-agent PA integration

### DIFF
--- a/.agent/backlog.md
+++ b/.agent/backlog.md
@@ -1,0 +1,14 @@
+# EAB Backlog
+
+## P1 — Active
+- [ ] Lint cleanup completion
+- [ ] Test coverage improvements
+
+## P2 — Soon
+- [ ] NXP LinkServer integration (MCX N947 secure flash)
+- [ ] Trace pipeline documentation
+- [ ] SystemView format support
+
+## P3 — Later
+- [ ] Additional board support
+- [ ] Performance optimization

--- a/.agent/handoff.md
+++ b/.agent/handoff.md
@@ -1,0 +1,14 @@
+# EAB Handoff
+
+## Key Files
+- `eab/` — Python package
+- `scripts/e2e-hardware-validation.sh` — full hardware test suite
+- `E2E_HARDWARE_VALIDATION.md` — process docs
+
+## Key Knowledge
+- ALWAYS use eabctl for ALL hardware operations
+- eab/cli/serial/ shadows pyserial — fixed daemon PYTHONPATH (commit 56565c9)
+- MCX N947 needs NXP LinkServer (probe-rs can't flash secure 0x10000000)
+- eabctl flash .elf for STM32 needs objcopy — use .bin instead
+- Zephyr SDK uses arm-zephyr-eabi-* not arm-none-eabi-*
+- Trace pipeline: eabctl rtt start → trace start --source rtt → .rttbin → trace export → Perfetto JSON

--- a/.agent/identity.md
+++ b/.agent/identity.md
@@ -1,0 +1,16 @@
+# Embedded Agent Bridge (EAB) Agent
+
+## Role
+Background daemons bridging AI coding agents to debuggers and embedded hardware. Supports ESP32, STM32, nRF, NXP MCX via serial, RTT, J-Link, OpenOCD.
+
+## Tools
+- eabctl CLI for all hardware operations
+- probe-rs for ARM debug
+- J-Link for nRF targets
+- OpenOCD for STM32
+- RTT binary capture + trace export
+
+## Communication
+- CLI: `eabctl` (installed via uv)
+- Python API: `from eab import ...`
+- 5 boards on USB hub: ESP32-C6, nRF5340 DK, STM32L4 Nucleo, FRDM-MCXN947, TI LaunchPad

--- a/.agent/state.md
+++ b/.agent/state.md
@@ -1,0 +1,14 @@
+# EAB State
+
+## Last Updated
+2026-02-28
+
+## Status
+Active — Phase 2 code-complete, E2E hardware validated
+
+## Current Focus
+- Lint cleanup (branch: refactor/lint-cleanup-v2)
+- Post-PR #121 stabilization
+
+## Blockers
+None — 15 pass, 0 fail, 5 skip on hardware tests


### PR DESCRIPTION
Adds `.agent/` folder with identity, state, backlog, handoff, and mailbox for the personal assistant multi-agent system.