### PR TITLE
fix(chip-info): VID/PID-aware auto port selection

### DIFF
--- a/eab/auto_detect.py
+++ b/eab/auto_detect.py
@@ -99,6 +99,54 @@ def detect_boards():
     return detect_boards_ioreg()
 
 
+def _chip_matches(requested: str, board_chip: str) -> bool:
+    """Check whether a user-requested chip id matches a KNOWN_BOARDS chip family.
+
+    Users pass specific variants (e.g. ``esp32c6``, ``esp32s3``) while
+    KNOWN_BOARDS records a chip family (e.g. ``esp32``). Match if either value
+    is a prefix of the other (case-insensitive).
+    """
+    if not requested or not board_chip:
+        return False
+    r = requested.lower()
+    b = board_chip.lower()
+    return r == b or r.startswith(b) or b.startswith(r)
+
+
+def resolve_port_for_chip(chip: str, boards=None):
+    """Resolve a serial port for the requested chip via USB VID/PID lookup.
+
+    Args:
+        chip: Chip identifier (e.g. ``"esp32c6"``, ``"mcxn947"``).
+        boards: Optional pre-detected boards list (for tests). If None,
+            calls ``detect_boards()``.
+
+    Returns:
+        Tuple ``(port, error)`` where:
+          - ``(port_str, None)``: exactly one matching port found.
+          - ``(None, "no_match")``: zero ports match the requested chip.
+          - ``(None, "ambiguous:<port1>,<port2>,...")``: multiple ports match.
+
+    This avoids the alphabetical-glob trap in which, e.g., an NXP MCU-Link
+    node (``/dev/cu.usbmodemI2WZW...``) beats an ESP32 node
+    (``/dev/cu.usbmodem101``) simply because capital-I sorts before digit-1.
+    """
+    if boards is None:
+        boards = detect_boards()
+
+    matches = [
+        b for b in boards
+        if b.get("port") and _chip_matches(chip, b.get("chip", ""))
+    ]
+
+    if not matches:
+        return (None, "no_match")
+    if len(matches) > 1:
+        ports = ",".join(sorted(b["port"] for b in matches))
+        return (None, f"ambiguous:{ports}")
+    return (matches[0]["port"], None)
+
+
 def print_table(boards):
     """Pretty-print detected boards."""
     if not boards:

--- a/eab/cli/flash/chip_info_cmd.py
+++ b/eab/cli/flash/chip_info_cmd.py
@@ -6,6 +6,7 @@ import subprocess
 import time
 from typing import Optional
 
+from eab.auto_detect import resolve_port_for_chip
 from eab.chips import get_chip_profile
 from eab.cli.helpers import _now_iso, _print
 
@@ -35,6 +36,48 @@ def cmd_chip_info(
     except ValueError as e:
         _print({"error": str(e)}, json_mode=json_mode)
         return 2
+
+    # Bug 1 fix: when no --port is given, resolve via USB VID/PID rather than
+    # letting esptool's own auto-detect pick an alphabetically-first serial
+    # node (which can be a non-ESP device, e.g. an NXP MCU-Link probe).
+    if not port:
+        resolved, err = resolve_port_for_chip(chip)
+        if resolved:
+            port = resolved
+        elif err == "no_match":
+            _print(
+                {
+                    "error": (
+                        f"No USB device matching chip '{chip}' detected. "
+                        "Plug in the board or pass --port explicitly."
+                    ),
+                    "schema_version": 1,
+                    "timestamp": _now_iso(),
+                    "success": False,
+                    "chip": chip,
+                    "duration_ms": 0,
+                },
+                json_mode=json_mode,
+            )
+            return 1
+        elif err and err.startswith("ambiguous:"):
+            ports = err.split(":", 1)[1]
+            _print(
+                {
+                    "error": (
+                        f"Multiple USB devices match chip '{chip}' ({ports}). "
+                        "Pass --port explicitly to disambiguate."
+                    ),
+                    "schema_version": 1,
+                    "timestamp": _now_iso(),
+                    "success": False,
+                    "chip": chip,
+                    "candidates": ports.split(","),
+                    "duration_ms": 0,
+                },
+                json_mode=json_mode,
+            )
+            return 1
 
     info_cmd = profile.get_chip_info_command(port=port or "")
 

--- a/eab/tests/test_chip_info_auto_port.py
+++ b/eab/tests/test_chip_info_auto_port.py
@@ -1,0 +1,184 @@
+"""Tests for chip-info VID/PID-aware auto port selection (Bug 1).
+
+Regression: ``eabctl chip-info --chip esp32c6`` (no ``--port``) used to fall
+through to esptool's own glob-sorted auto-detect, which picks the
+alphabetically-first ``/dev/cu.usbmodem*`` node. When an NXP MCU-Link probe
+is plugged in alongside an ESP32-C6, the NXP node
+(``/dev/cu.usbmodemI2WZW2OTY3RUW3``) beats the ESP32 node
+(``/dev/cu.usbmodem101``) because capital-I sorts before digit-1. Wasted
+~14s per probe and caused spurious "chip not found" errors.
+
+Fix: when port is None, call :func:`eab.auto_detect.resolve_port_for_chip`
+which filters USB devices by VID/PID against ``KNOWN_BOARDS``.
+"""
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from eab.auto_detect import _chip_matches, resolve_port_for_chip
+from eab.cli.flash import chip_info_cmd
+
+
+ESP32_BOARD = {
+    "name": "ESP32 USB-JTAG",
+    "chip": "esp32",
+    "probe": "esp-usb-jtag",
+    "port": "/dev/cu.usbmodem101",
+    "vid": "303a",
+    "pid": "1001",
+    "serial": "F0:F5:BD:01:88:2C",
+}
+
+NXP_BOARD = {
+    "name": "FRDM-MCXN947",
+    "chip": "mcxn947",
+    "probe": "cmsis-dap",
+    "port": "/dev/cu.usbmodemI2WZW2OTY3RUW3",
+    "vid": "1fc9",
+    "pid": "0143",
+    "serial": "I2WZW2OTY3RUW",
+}
+
+
+class TestChipMatches:
+    def test_exact_match(self):
+        assert _chip_matches("esp32", "esp32") is True
+
+    def test_variant_matches_family(self):
+        # User asks for "esp32c6", KNOWN_BOARDS records "esp32"
+        assert _chip_matches("esp32c6", "esp32") is True
+
+    def test_family_matches_variant(self):
+        assert _chip_matches("esp32", "esp32c6") is True
+
+    def test_case_insensitive(self):
+        assert _chip_matches("ESP32C6", "esp32") is True
+
+    def test_distinct_chips(self):
+        assert _chip_matches("esp32c6", "mcxn947") is False
+        assert _chip_matches("stm32", "esp32") is False
+
+    def test_empty_inputs(self):
+        assert _chip_matches("", "esp32") is False
+        assert _chip_matches("esp32", "") is False
+
+
+class TestResolvePortForChip:
+    def test_picks_esp32_not_nxp_when_both_present(self):
+        """The real-world failure: both an ESP32 and an NXP probe are plugged in.
+
+        Alphabetical sort puts the NXP node first. VID/PID resolver must
+        still return the ESP32 node when the user asks for esp32c6.
+        """
+        port, err = resolve_port_for_chip("esp32c6", boards=[NXP_BOARD, ESP32_BOARD])
+        assert port == "/dev/cu.usbmodem101"
+        assert err is None
+
+    def test_picks_nxp_when_requested(self):
+        port, err = resolve_port_for_chip("mcxn947", boards=[NXP_BOARD, ESP32_BOARD])
+        assert port == "/dev/cu.usbmodemI2WZW2OTY3RUW3"
+        assert err is None
+
+    def test_returns_no_match_when_chip_absent(self):
+        port, err = resolve_port_for_chip("stm32", boards=[NXP_BOARD, ESP32_BOARD])
+        assert port is None
+        assert err == "no_match"
+
+    def test_returns_ambiguous_when_multiple_match(self):
+        second_esp = dict(ESP32_BOARD, port="/dev/cu.usbmodem102", serial="AA:BB")
+        port, err = resolve_port_for_chip("esp32c6", boards=[ESP32_BOARD, second_esp])
+        assert port is None
+        assert err is not None and err.startswith("ambiguous:")
+        assert "/dev/cu.usbmodem101" in err
+        assert "/dev/cu.usbmodem102" in err
+
+    def test_boards_with_empty_port_are_skipped(self):
+        """ioreg detection returns empty port string — must not false-match."""
+        no_port = dict(NXP_BOARD, port="")
+        port, err = resolve_port_for_chip("mcxn947", boards=[no_port])
+        assert port is None
+        assert err == "no_match"
+
+
+class TestChipInfoCmdAutoPort:
+    def test_auto_port_picks_esp32_over_nxp(self):
+        """End-to-end: cmd_chip_info with port=None, two USB devices present,
+        must invoke esptool against the ESP32 port — not the NXP port.
+        """
+        captured: dict = {}
+
+        def fake_run(cmd_list, capture_output, text, timeout):
+            captured["cmd"] = cmd_list
+            result = mock.Mock()
+            result.returncode = 0
+            result.stdout = "Chip is ESP32-C6"
+            result.stderr = ""
+            return result
+
+        with mock.patch(
+            "eab.cli.flash.chip_info_cmd.resolve_port_for_chip",
+            return_value=("/dev/cu.usbmodem101", None),
+        ), mock.patch(
+            "eab.cli.flash.chip_info_cmd.subprocess.run",
+            side_effect=fake_run,
+        ):
+            rc = chip_info_cmd.cmd_chip_info(chip="esp32c6", port=None, json_mode=True)
+
+        assert rc == 0
+        # Critical: esptool was invoked with the ESP32 node, not the NXP node.
+        assert "/dev/cu.usbmodem101" in captured["cmd"]
+        assert "/dev/cu.usbmodemI2WZW2OTY3RUW3" not in captured["cmd"]
+
+    def test_auto_port_no_match_returns_error(self, capsys):
+        with mock.patch(
+            "eab.cli.flash.chip_info_cmd.resolve_port_for_chip",
+            return_value=(None, "no_match"),
+        ):
+            rc = chip_info_cmd.cmd_chip_info(chip="esp32c6", port=None, json_mode=True)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "No USB device matching chip" in out
+
+    def test_auto_port_ambiguous_returns_error(self, capsys):
+        err = "ambiguous:/dev/cu.usbmodem101,/dev/cu.usbmodem102"
+        with mock.patch(
+            "eab.cli.flash.chip_info_cmd.resolve_port_for_chip",
+            return_value=(None, err),
+        ):
+            rc = chip_info_cmd.cmd_chip_info(chip="esp32c6", port=None, json_mode=True)
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "Multiple USB devices" in out
+        assert "--port" in out
+
+    def test_explicit_port_skips_resolver(self):
+        """If --port is passed, resolver must not be called; esptool gets the
+        explicit port unchanged.
+        """
+        captured: dict = {}
+
+        def fake_run(cmd_list, capture_output, text, timeout):
+            captured["cmd"] = cmd_list
+            result = mock.Mock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            return result
+
+        with mock.patch(
+            "eab.cli.flash.chip_info_cmd.resolve_port_for_chip",
+        ) as resolver, mock.patch(
+            "eab.cli.flash.chip_info_cmd.subprocess.run",
+            side_effect=fake_run,
+        ):
+            rc = chip_info_cmd.cmd_chip_info(
+                chip="esp32c6",
+                port="/dev/cu.usbmodem999",
+                json_mode=True,
+            )
+
+        assert rc == 0
+        resolver.assert_not_called()
+        assert "/dev/cu.usbmodem999" in captured["cmd"]


### PR DESCRIPTION
## Summary

Fixes #182. When `eabctl chip-info --chip esp32c6` is invoked without
`--port`, select the serial device by matching the requested chip
against USB VID/PID from `KNOWN_BOARDS` rather than deferring to
esptool's alphabetical-glob auto-detect.

Before: with an NXP MCU-Link probe (`/dev/cu.usbmodemI2WZW2OTY3RUW3`)
plugged in alongside an ESP32-C6 (`/dev/cu.usbmodem101`), the NXP node
won every `chip-info` probe (capital-I sorts before digit-1) and ate
~14s per call on esptool timeouts.

After: `chip-info` picks the ESP32 node directly; errors cleanly with
guidance when no match or multiple matches.

## Changes

- **`eab/auto_detect.py`**: add `resolve_port_for_chip(chip) -> (port, err)`.
  Returns `(port, None)` on unique match, `(None, "no_match")` when zero
  ports match, or `(None, "ambiguous:<ports>")` when multiple match.
  Handles the `esp32c6` → `esp32` family/variant mismatch via a
  prefix-match helper.
- **`eab/cli/flash/chip_info_cmd.py`**: call the resolver when `port`
  is None. Error out with a clear message on no-match / ambiguous;
  delegate to esptool with the resolved port on success.
- **`eab/tests/test_chip_info_auto_port.py`**: 15 new tests covering
  the NXP-vs-ESP32 regression, variant matching, ambiguity handling,
  and explicit-port bypass.

## Test results

- Test count: **2145 → 2160** (+15, all passing)
- No existing tests modified; no existing tests regressed.

```
$ python3 -m pytest eab/tests/test_chip_info_auto_port.py eab/tests/test_esp32_commands.py -q
78 passed in 0.72s
```

## Out of scope

- **Bug 2** (daemon doesn't escalate crash-loops) — tracked in #183,
  design-sketch only, awaiting Shane's review.
- **Bug 3** (dueling launchd plists) — tracked in #184, docs/install
  fix only.
- **Daemon `_resolve_port` regex bug** at `eab/daemon.py:324`
  (`r"(\\d+)$"` — raw-string double-escape, never matches numeric
  suffixes). Related to this issue but a different code path. Noted
  in #182, happy to file a follow-up.

## Evidence

Full diagnostic report that motivated this fix:
`work/agent-reports/2026-04-17-eab-diagnostic-deep.md` in the PA
workspace (private).

Do NOT merge yet — waiting on Shane's review.