### PR TITLE
feat: flock device, eabctl build (Docker), Linux auto_detect, daemon regex fix

### DIFF
--- a/eab/auto_detect.py
+++ b/eab/auto_detect.py
@@ -10,11 +10,43 @@ Usage:
 """
 
 import argparse
+import glob
 import json
 import re
 import subprocess
 import sys
 from pathlib import Path
+
+# Device-node glob patterns for systems without a functioning pyserial backend.
+# Ordered roughly by distinctiveness. macOS uses /dev/cu.*; Linux exposes
+# /dev/ttyUSB* (FTDI/CH340/CP210x) and /dev/ttyACM* (CDC-ACM such as
+# USB-JTAG/native-USB); some macOS native-USB ports appear as
+# /dev/tty.usbmodem*. Windows (COM*) is handled via pyserial only.
+_DEVICE_NODE_GLOBS = (
+    "/dev/ttyUSB*",      # Linux FTDI/CH340/CP210x
+    "/dev/ttyACM*",      # Linux CDC-ACM (native USB, J-Link VCP)
+    "/dev/tty.usbmodem*", # macOS native USB (tty form)
+    "/dev/tty.usbserial*",# macOS FTDI/CP210x (tty form)
+    "/dev/cu.usbmodem*",  # macOS native USB (cu form)
+    "/dev/cu.usbserial*", # macOS FTDI/CP210x (cu form)
+)
+
+
+def list_device_nodes() -> list[str]:
+    """Return candidate serial device-node paths via glob.
+
+    Linux-compatible fallback for environments without pyserial or when the
+    pyserial enumeration misses a just-appeared node. Does NOT read or open
+    the nodes — only lists paths.
+    """
+    found: list[str] = []
+    seen: set[str] = set()
+    for pattern in _DEVICE_NODE_GLOBS:
+        for path in glob.glob(pattern):
+            if path not in seen:
+                seen.add(path)
+                found.append(path)
+    return found
 
 KNOWN_BOARDS = {
     ("1fc9", "0143"): {"name": "FRDM-MCXN947", "chip": "mcxn947", "probe": "cmsis-dap"},
@@ -29,13 +61,25 @@ KNOWN_BOARDS = {
 
 
 def detect_boards_pyserial():
-    """Detect boards using pyserial."""
+    """Detect boards using pyserial.
+
+    Primary path: enumerate via ``serial.tools.list_ports.comports()`` and
+    resolve ``(vid, pid)`` against ``KNOWN_BOARDS``. The VID/PID match is
+    the source of truth for chip / probe identification.
+
+    Secondary path (Linux compat): if pyserial returns ports that lack VID/PID
+    (common on some Linux kernels and for virtual CDC-ACM nodes), we still
+    surface the raw device-node paths from ``list_device_nodes()`` as
+    ``unknown`` entries so callers that just need a port path to tail can
+    find something. Existing VID/PID-resolved entries are kept intact.
+    """
     try:
         import serial.tools.list_ports
     except ImportError:
         return None
 
     boards = []
+    claimed_ports: set[str] = set()
     for p in serial.tools.list_ports.comports():
         vid = f"{p.vid:04x}" if p.vid else None
         pid = f"{p.pid:04x}" if p.pid else None
@@ -46,6 +90,23 @@ def detect_boards_pyserial():
             info["pid"] = pid
             info["serial"] = p.serial_number or ""
             boards.append(info)
+            claimed_ports.add(p.device)
+
+    # Linux/macOS fallback: surface device-node globs that pyserial did not
+    # resolve to a known VID/PID. Lets agents see /dev/ttyUSB0, /dev/ttyACM1,
+    # /dev/tty.usbmodem* even when they're not in KNOWN_BOARDS yet.
+    for path in list_device_nodes():
+        if path in claimed_ports:
+            continue
+        boards.append({
+            "name": "Unknown USB serial",
+            "chip": "",
+            "probe": "",
+            "port": path,
+            "vid": "",
+            "pid": "",
+            "serial": "",
+        })
     return boards
 
 

--- a/eab/cli/build_cmd.py
+++ b/eab/cli/build_cmd.py
@@ -1,0 +1,167 @@
+"""`eabctl build` — wrap ESP-IDF builds in the official Espressif Docker image.
+
+This subcommand produces a reproducible, host-OS-independent ESP-IDF build by
+invoking ``espressif/idf:<idf-version>`` with the project directory
+bind-mounted at ``/project``. It is a thin wrapper:
+
+  docker run --rm \
+      -v <project-dir>:/project \
+      -w /project \
+      -e IDF_TARGET=<target> \
+      [--pull=never]          # when --no-pull
+      espressif/idf:<version> \
+      idf.py build
+
+It is intentionally decoupled from the running EAB daemon — builds do not
+touch serial, RTT, or any probe. Flashing remains the exclusive job of
+``eabctl flash`` (which handles daemon pause, port release, chip detection,
+and runner selection).
+
+Defaults:
+    --target       esp32c6
+    --idf-version  v5.4.1
+    --project-dir  $PWD
+
+Preflight: we require ``docker info`` to succeed before attempting the build.
+If it fails we return an actionable error pointing at Colima (macOS / Mac
+Studio) or ``systemctl start docker`` (Linux). Windows users are directed to
+Docker Desktop.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from typing import List, Optional
+
+from eab.cli.helpers import _print
+
+
+DEFAULT_TARGET = "esp32c6"
+DEFAULT_IDF_VERSION = "v5.4.1"
+
+DOCKER_UNREACHABLE_HINT = (
+    "Docker daemon unreachable. On Mac Studio: 'colima start' (Colima is "
+    "opt-in; see docs/mac-studio-setup.md). On Linux: 'sudo systemctl start "
+    "docker'."
+)
+
+
+def build_docker_command(
+    *,
+    project_dir: str,
+    target: str,
+    idf_version: str,
+    no_pull: bool,
+) -> List[str]:
+    """Assemble the ``docker run`` argv for an ESP-IDF build.
+
+    Pure function — makes unit testing trivial (no subprocess, no env).
+
+    Args:
+        project_dir: Absolute path to ESP-IDF project on host.
+        target: Espressif chip target (``esp32c6``, ``esp32s3`` …).
+        idf_version: ESP-IDF docker tag (``v5.4.1``).
+        no_pull: Pass ``--pull=never`` to skip registry lookup.
+
+    Returns:
+        The argv list for ``subprocess.run``.
+    """
+    cmd: List[str] = [
+        "docker",
+        "run",
+        "--rm",
+        "-v",
+        f"{project_dir}:/project",
+        "-w",
+        "/project",
+        "-e",
+        f"IDF_TARGET={target}",
+    ]
+    if no_pull:
+        cmd.append("--pull=never")
+    cmd.append(f"espressif/idf:{idf_version}")
+    cmd.extend(["idf.py", "build"])
+    return cmd
+
+
+def _docker_preflight() -> Optional[str]:
+    """Return None if docker is reachable, else an error string."""
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except FileNotFoundError:
+        return "docker: command not found. Install Docker or Colima."
+    except subprocess.TimeoutExpired:
+        return DOCKER_UNREACHABLE_HINT
+    except Exception as exc:  # pragma: no cover - defensive
+        return f"docker info failed: {exc}"
+
+    if result.returncode != 0:
+        return DOCKER_UNREACHABLE_HINT
+    return None
+
+
+def cmd_build(
+    *,
+    target: str = DEFAULT_TARGET,
+    idf_version: str = DEFAULT_IDF_VERSION,
+    project_dir: Optional[str] = None,
+    no_pull: bool = False,
+    json_mode: bool = False,
+) -> int:
+    """Dockerized ``idf.py build`` runner.
+
+    Returns:
+        Exit code from ``docker run`` (passes through), or non-zero on preflight.
+    """
+    resolved_project_dir = os.path.abspath(project_dir or os.getcwd())
+
+    preflight_err = _docker_preflight()
+    if preflight_err is not None:
+        _print(
+            {"ok": False, "error": preflight_err, "hint": DOCKER_UNREACHABLE_HINT},
+            json_mode=json_mode,
+        )
+        return 1
+
+    argv = build_docker_command(
+        project_dir=resolved_project_dir,
+        target=target,
+        idf_version=idf_version,
+        no_pull=no_pull,
+    )
+
+    if json_mode:
+        # Emit plan before execution for agent traceability.
+        print(
+            json.dumps(
+                {
+                    "ok": True,
+                    "phase": "plan",
+                    "command": argv,
+                    "target": target,
+                    "idf_version": idf_version,
+                    "project_dir": resolved_project_dir,
+                    "no_pull": no_pull,
+                },
+                indent=2,
+            ),
+            flush=True,
+        )
+
+    # Stream stdout/stderr through to the caller — no capture. This matches
+    # the ergonomics of ``idf.py build`` when run directly.
+    try:
+        result = subprocess.run(argv, check=False)
+    except FileNotFoundError:
+        _print({"ok": False, "error": "docker binary vanished between preflight and run"},
+               json_mode=json_mode)
+        return 1
+
+    return result.returncode

--- a/eab/cli/daemon/device_mgmt_cmds.py
+++ b/eab/cli/daemon/device_mgmt_cmds.py
@@ -2,9 +2,32 @@
 
 from __future__ import annotations
 
+import os
+
 from eab.singleton import check_singleton
 from eab.device_registry import list_devices, register_device, unregister_device
 from eab.cli.helpers import _now_iso, _print
+
+
+def _device_status(d) -> str:
+    """Resolve a device's surfaced status.
+
+    When the daemon has written a ``port_flock.status`` sentinel into the
+    session directory (see ``daemon.py``), that takes precedence over
+    running/stopped — the daemon failed to acquire the advisory flock on
+    the device node, meaning something else (esptool, screen, pio, another
+    EAB) owns it. Reported as ``port-locked-by-other`` so agents can react.
+    """
+    try:
+        sentinel = os.path.join(d.base_dir, "port_flock.status")
+        if d.base_dir and os.path.isfile(sentinel):
+            with open(sentinel, "r") as fh:
+                value = fh.read().strip()
+            if value:
+                return value
+    except Exception:
+        pass
+    return "running" if d.is_alive else "stopped"
 
 
 def cmd_devices(*, json_mode: bool) -> int:
@@ -27,7 +50,7 @@ def cmd_devices(*, json_mode: bool) -> int:
                     "name": d.device_name,
                     "type": d.device_type,
                     "chip": d.chip,
-                    "status": "running" if d.is_alive else "stopped",
+                    "status": _device_status(d),
                     "pid": d.pid,
                     "port": d.port,
                     "base_dir": d.base_dir,
@@ -42,7 +65,7 @@ def cmd_devices(*, json_mode: bool) -> int:
             print("No devices registered. Use: eabctl device add <name> --type debug --chip <chip>")
         else:
             for d in devices:
-                status = "running" if d.is_alive else "stopped"
+                status = _device_status(d)
                 chip_str = f" ({d.chip})" if d.chip else ""
                 port_str = f" port={d.port}" if d.port else ""
                 pid_str = f" pid={d.pid}" if d.pid else ""

--- a/eab/cli/dispatch.py
+++ b/eab/cli/dispatch.py
@@ -328,6 +328,16 @@ def main(argv: Optional[list[str]] = None) -> int:
         )
     if args.cmd == "diagnose":
         return cli.cmd_diagnose(base_dir=base_dir, json_mode=args.json)
+    if args.cmd == "build":
+        from eab.cli.build_cmd import cmd_build
+
+        return cmd_build(
+            target=args.target,
+            idf_version=args.idf_version,
+            project_dir=args.project_dir,
+            no_pull=args.no_pull,
+            json_mode=args.json,
+        )
     if args.cmd == "flash":
         return cli.cmd_flash(
             firmware=args.firmware,

--- a/eab/cli/parser.py
+++ b/eab/cli/parser.py
@@ -373,6 +373,32 @@ def _build_parser() -> argparse.ArgumentParser:
 
     sub.add_parser("diagnose", help="Run basic health checks and print recommendations")
 
+    # Dockerized ESP-IDF build wrapper — no hardware interaction.
+    p_build = sub.add_parser(
+        "build",
+        help="Build ESP-IDF project via Docker (espressif/idf image)",
+    )
+    p_build.add_argument(
+        "--target",
+        default="esp32c6",
+        help="ESP chip target (esp32c6, esp32s3, esp32h2, etc.). Default: esp32c6",
+    )
+    p_build.add_argument(
+        "--idf-version",
+        default="v5.4.1",
+        help="ESP-IDF docker tag (default: v5.4.1)",
+    )
+    p_build.add_argument(
+        "--project-dir",
+        default=None,
+        help="Path to ESP-IDF project (default: current working directory)",
+    )
+    p_build.add_argument(
+        "--no-pull",
+        action="store_true",
+        help="Pass --pull=never to docker run (use local image only)",
+    )
+
     # Flash operations (chip-agnostic)
     p_flash = sub.add_parser("flash", help="Flash firmware to device")
     p_flash.add_argument("firmware", help="Path to firmware binary (.bin/.hex/.elf) or ESP-IDF project directory")

--- a/eab/daemon.py
+++ b/eab/daemon.py
@@ -321,7 +321,10 @@ class SerialDaemon:
                 import re
 
                 def score(dev: str) -> tuple[int, str]:
-                    m = re.search(r"(\\d+)$", dev)
+                    # Fix #182: regex was double-escaped; restored standard
+                    # trailing-digit match so candidate ports tie-break by
+                    # numeric suffix (e.g. usbmodem14101 vs 14102).
+                    m = re.search(r"(\d+)$", dev)
                     return (int(m.group(1)) if m else -1, dev)
 
                 chosen = max(unique_candidates, key=score)
@@ -464,7 +467,40 @@ class SerialDaemon:
         if not self._reconnection.connect():
             self._logger.error("Failed to connect to serial port")
             self._port_lock.release()
-            self._emit_event("daemon_start_failed", {"reason": "connect_failed", "port": port_name}, level="error")
+
+            # If the serial open failed because another process holds an
+            # advisory flock on the device node, surface that specifically.
+            flock_status: Optional[str] = None
+            try:
+                from eab.implementations import get_last_flock_status
+                flock_status = get_last_flock_status()
+            except Exception:
+                flock_status = None
+
+            if flock_status == "port-locked-by-other":
+                self._logger.error(
+                    f"Port {port_name} is flock-held by another process "
+                    f"(esptool, screen, pio, or another EAB). Refusing to "
+                    f"start device thread. Status: port-locked-by-other"
+                )
+                try:
+                    self._fs.write_file(
+                        os.path.join(self._base_dir, "port_flock.status"),
+                        "port-locked-by-other\n",
+                    )
+                except Exception:
+                    pass
+                self._emit_event(
+                    "daemon_start_failed",
+                    {"reason": "port_flock_held", "port": port_name, "status": "port-locked-by-other"},
+                    level="error",
+                )
+            else:
+                self._emit_event(
+                    "daemon_start_failed",
+                    {"reason": "connect_failed", "port": port_name},
+                    level="error",
+                )
             return False
 
         # Generate session ID

--- a/eab/implementations.py
+++ b/eab/implementations.py
@@ -7,7 +7,9 @@ and implement the abstract interfaces.
 
 from typing import Optional, List
 from datetime import datetime
+import errno
 import os
+import sys
 import time
 
 import serial
@@ -18,25 +20,97 @@ from .interfaces import (
     PortInfo
 )
 
+# fcntl is POSIX-only. On Windows the flock step is skipped gracefully — the
+# device_node-level flock guard is redundant there anyway (Windows already
+# exclusively locks COM port handles). See #flock-and-docker-build PR.
+try:
+    import fcntl  # type: ignore
+    _HAS_FCNTL = True
+except Exception:  # pragma: no cover - non-POSIX
+    fcntl = None  # type: ignore
+    _HAS_FCNTL = False
+
+
+# Last flock failure reason. Set by RealSerialPort.open() when LOCK_EX|LOCK_NB
+# raises EAGAIN/EWOULDBLOCK so the daemon can surface
+# status="port-locked-by-other" in `eabctl devices --json`.
+_LAST_FLOCK_STATUS: Optional[str] = None
+
+
+def get_last_flock_status() -> Optional[str]:
+    """Return last flock status set by RealSerialPort.open(), or None.
+
+    Values: None (ok / no attempt), "port-locked-by-other" (EAGAIN on LOCK_EX|LOCK_NB).
+    """
+    return _LAST_FLOCK_STATUS
+
+
+def _set_flock_status(value: Optional[str]) -> None:
+    global _LAST_FLOCK_STATUS
+    _LAST_FLOCK_STATUS = value
+
 
 class RealSerialPort(SerialPortInterface):
     """
     Real serial port implementation using pyserial.
+
+    Additionally acquires an advisory ``fcntl.flock(LOCK_EX | LOCK_NB)`` on the
+    underlying device-node file descriptor for the lifetime of the open
+    session. This catches the case where another non-EAB process (esptool,
+    screen, pio) has the device open — it complements the file-based
+    ``PortLock`` which only arbitrates between EAB daemons.
+
+    On pause/resume the daemon closes the serial port (releasing the flock)
+    and re-opens it (re-acquiring). On EAGAIN the open fails and
+    ``get_last_flock_status()`` returns ``"port-locked-by-other"``.
     """
 
     def __init__(self):
         self._serial: Optional[serial.Serial] = None
 
     def open(self, port: str, baud: int, timeout: float = 1.0) -> bool:
+        _set_flock_status(None)
         try:
             self._serial = serial.Serial(port, baud, timeout=timeout)
-            return True
         except Exception:
             self._serial = None
             return False
 
+        # Acquire non-blocking exclusive flock on the device-node fd.
+        if _HAS_FCNTL:
+            try:
+                fd = self._serial.fileno()
+            except Exception:
+                fd = None
+            if fd is not None:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except (OSError, IOError) as e:
+                    err = getattr(e, "errno", None)
+                    if err in (errno.EAGAIN, errno.EWOULDBLOCK):
+                        _set_flock_status("port-locked-by-other")
+                    else:
+                        _set_flock_status("port-locked-by-other")
+                    try:
+                        self._serial.close()
+                    except Exception:
+                        pass
+                    self._serial = None
+                    return False
+        return True
+
     def close(self) -> None:
         if self._serial:
+            # Releasing the fd via close() implicitly drops the flock.
+            try:
+                if _HAS_FCNTL:
+                    try:
+                        fd = self._serial.fileno()
+                        fcntl.flock(fd, fcntl.LOCK_UN)
+                    except Exception:
+                        pass
+            except Exception:
+                pass
             try:
                 self._serial.close()
             except Exception:

--- a/eab/tests/test_auto_detect_linux.py
+++ b/eab/tests/test_auto_detect_linux.py
@@ -1,0 +1,118 @@
+"""Unit tests for Feature 3 — Linux compat in ``eab.auto_detect``.
+
+Mocks ``glob.glob`` entirely. Never touches ``/dev/*``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def test_list_device_nodes_linux_patterns():
+    """Linux-style device paths surface from glob."""
+    import eab.auto_detect as ad
+
+    fake_results = {
+        "/dev/ttyUSB*": ["/dev/ttyUSB0", "/dev/ttyUSB1"],
+        "/dev/ttyACM*": ["/dev/ttyACM0"],
+        "/dev/tty.usbmodem*": [],
+        "/dev/tty.usbserial*": [],
+        "/dev/cu.usbmodem*": [],
+        "/dev/cu.usbserial*": [],
+    }
+    with patch.object(ad, "glob") as mock_glob:
+        mock_glob.glob.side_effect = lambda pat: fake_results.get(pat, [])
+        nodes = ad.list_device_nodes()
+
+    assert "/dev/ttyUSB0" in nodes
+    assert "/dev/ttyUSB1" in nodes
+    assert "/dev/ttyACM0" in nodes
+
+
+def test_list_device_nodes_macos_patterns():
+    """macOS-style device paths surface from glob."""
+    import eab.auto_detect as ad
+
+    fake_results = {
+        "/dev/ttyUSB*": [],
+        "/dev/ttyACM*": [],
+        "/dev/tty.usbmodem*": ["/dev/tty.usbmodem14101"],
+        "/dev/tty.usbserial*": [],
+        "/dev/cu.usbmodem*": ["/dev/cu.usbmodem14101"],
+        "/dev/cu.usbserial*": ["/dev/cu.usbserial-0001"],
+    }
+    with patch.object(ad, "glob") as mock_glob:
+        mock_glob.glob.side_effect = lambda pat: fake_results.get(pat, [])
+        nodes = ad.list_device_nodes()
+
+    assert "/dev/tty.usbmodem14101" in nodes
+    assert "/dev/cu.usbmodem14101" in nodes
+    assert "/dev/cu.usbserial-0001" in nodes
+
+
+def test_list_device_nodes_dedupes():
+    """Same path returned by multiple patterns only appears once."""
+    import eab.auto_detect as ad
+
+    with patch.object(ad, "glob") as mock_glob:
+        mock_glob.glob.side_effect = lambda pat: ["/dev/ttyUSB0"]
+        nodes = ad.list_device_nodes()
+
+    assert nodes.count("/dev/ttyUSB0") == 1
+
+
+def test_detect_boards_pyserial_preserves_vid_pid_match():
+    """Existing VID/PID logic still works when pyserial reports a known board."""
+    import eab.auto_detect as ad
+
+    fake_port = MagicMock()
+    fake_port.vid = 0x1366  # J-Link
+    fake_port.pid = 0x1015
+    fake_port.device = "/dev/ttyACM0"
+    fake_port.serial_number = "000261012345"
+
+    import types
+    fake_serial_tools = types.SimpleNamespace()
+    fake_list_ports = types.SimpleNamespace(comports=lambda: [fake_port])
+    fake_serial_tools.list_ports = fake_list_ports
+
+    import sys
+
+    with patch.dict(sys.modules, {
+        "serial": types.SimpleNamespace(tools=fake_serial_tools),
+        "serial.tools": fake_serial_tools,
+        "serial.tools.list_ports": fake_list_ports,
+    }), patch.object(ad, "list_device_nodes", return_value=[]):
+        boards = ad.detect_boards_pyserial()
+
+    assert boards is not None
+    match = [b for b in boards if b.get("vid") == "1366"]
+    assert match, "J-Link VID/PID should resolve to known board"
+    assert match[0]["name"] == "J-Link"
+    assert match[0]["port"] == "/dev/ttyACM0"
+
+
+def test_detect_boards_pyserial_adds_linux_nodes_as_unknown():
+    """Unclaimed Linux device nodes appear as unknown-serial entries."""
+    import eab.auto_detect as ad
+    import sys
+    import types
+
+    # pyserial reports nothing.
+    fake_list_ports = types.SimpleNamespace(comports=lambda: [])
+    fake_serial_tools = types.SimpleNamespace(list_ports=fake_list_ports)
+
+    with patch.dict(sys.modules, {
+        "serial": types.SimpleNamespace(tools=fake_serial_tools),
+        "serial.tools": fake_serial_tools,
+        "serial.tools.list_ports": fake_list_ports,
+    }), patch.object(ad, "list_device_nodes", return_value=["/dev/ttyUSB0", "/dev/ttyACM1"]):
+        boards = ad.detect_boards_pyserial()
+
+    ports = [b["port"] for b in boards]
+    assert "/dev/ttyUSB0" in ports
+    assert "/dev/ttyACM1" in ports
+    # Unknown entries should not claim vid/pid
+    unknown = [b for b in boards if b["port"] == "/dev/ttyUSB0"]
+    assert unknown[0]["vid"] == ""
+    assert unknown[0]["pid"] == ""

--- a/eab/tests/test_build_cmd.py
+++ b/eab/tests/test_build_cmd.py
@@ -1,0 +1,213 @@
+"""Unit tests for Feature 2 — ``eabctl build`` dockerized wrapper.
+
+All ``subprocess.run`` calls are mocked. No ``docker run`` is ever executed.
+No network access. No hardware.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Pure-function tests: docker-run argv construction.
+# ---------------------------------------------------------------------------
+
+def test_build_docker_command_defaults():
+    from eab.cli.build_cmd import build_docker_command
+
+    argv = build_docker_command(
+        project_dir="/home/user/esp-proj",
+        target="esp32c6",
+        idf_version="v5.4.1",
+        no_pull=False,
+    )
+    assert argv[0] == "docker"
+    assert argv[1] == "run"
+    assert "--rm" in argv
+    # volume mount
+    assert "-v" in argv
+    assert "/home/user/esp-proj:/project" in argv
+    # workdir
+    wi = argv.index("-w")
+    assert argv[wi + 1] == "/project"
+    # env
+    ei = argv.index("-e")
+    assert argv[ei + 1] == "IDF_TARGET=esp32c6"
+    # image
+    assert "espressif/idf:v5.4.1" in argv
+    # final command
+    assert argv[-2:] == ["idf.py", "build"]
+    # no --pull when no_pull is False
+    assert "--pull=never" not in argv
+
+
+def test_build_docker_command_no_pull_flag():
+    from eab.cli.build_cmd import build_docker_command
+
+    argv = build_docker_command(
+        project_dir="/tmp/proj",
+        target="esp32c6",
+        idf_version="v5.4.1",
+        no_pull=True,
+    )
+    assert "--pull=never" in argv
+    # --pull=never must appear before the image tag
+    idx_pull = argv.index("--pull=never")
+    idx_image = argv.index("espressif/idf:v5.4.1")
+    assert idx_pull < idx_image
+
+
+@pytest.mark.parametrize("target", ["esp32c6", "esp32s3", "esp32h2"])
+def test_build_docker_command_target_parametrized(target):
+    from eab.cli.build_cmd import build_docker_command
+
+    argv = build_docker_command(
+        project_dir="/tmp/proj",
+        target=target,
+        idf_version="v5.4.1",
+        no_pull=False,
+    )
+    ei = argv.index("-e")
+    assert argv[ei + 1] == f"IDF_TARGET={target}"
+
+
+# ---------------------------------------------------------------------------
+# cmd_build: preflight + exit-code pass-through, all subprocess.run mocked.
+# ---------------------------------------------------------------------------
+
+def _make_completed(returncode: int):
+    res = MagicMock()
+    res.returncode = returncode
+    res.stdout = ""
+    res.stderr = ""
+    return res
+
+
+def test_cmd_build_preflight_success_runs_build(capsys):
+    from eab.cli.build_cmd import cmd_build
+
+    # First call: docker info (preflight). Second: docker run (actual build).
+    call_log = []
+
+    def fake_run(argv, *args, **kwargs):
+        call_log.append(list(argv))
+        if argv[:2] == ["docker", "info"]:
+            return _make_completed(0)
+        # simulate build success
+        return _make_completed(0)
+
+    with patch("eab.cli.build_cmd.subprocess.run", side_effect=fake_run):
+        rc = cmd_build(
+            target="esp32c6",
+            idf_version="v5.4.1",
+            project_dir="/tmp/proj",
+            no_pull=False,
+            json_mode=False,
+        )
+
+    assert rc == 0
+    # Two subprocess calls expected
+    assert len(call_log) == 2
+    assert call_log[0][:2] == ["docker", "info"]
+    # Second call is the assembled build command
+    build_argv = call_log[1]
+    assert build_argv[0] == "docker"
+    assert build_argv[1] == "run"
+    assert "espressif/idf:v5.4.1" in build_argv
+    assert "IDF_TARGET=esp32c6" in build_argv
+
+
+def test_cmd_build_preflight_failure_actionable_error(capsys):
+    from eab.cli.build_cmd import cmd_build
+    from eab.cli.build_cmd import DOCKER_UNREACHABLE_HINT
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["docker", "info"]:
+            return _make_completed(1)
+        pytest.fail("build should not run when preflight fails")
+
+    with patch("eab.cli.build_cmd.subprocess.run", side_effect=fake_run):
+        rc = cmd_build(
+            target="esp32c6",
+            idf_version="v5.4.1",
+            project_dir="/tmp/proj",
+            no_pull=False,
+            json_mode=True,
+        )
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Docker daemon unreachable" in combined
+    assert DOCKER_UNREACHABLE_HINT in combined
+    assert "colima start" in combined
+    assert "systemctl start docker" in combined
+
+
+def test_cmd_build_preflight_file_not_found(capsys):
+    from eab.cli.build_cmd import cmd_build
+
+    with patch(
+        "eab.cli.build_cmd.subprocess.run",
+        side_effect=FileNotFoundError("docker"),
+    ):
+        rc = cmd_build(
+            target="esp32c6",
+            idf_version="v5.4.1",
+            project_dir="/tmp/proj",
+            no_pull=False,
+            json_mode=True,
+        )
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "command not found" in (captured.out + captured.err).lower()
+
+
+def test_cmd_build_no_pull_flag_propagates():
+    from eab.cli.build_cmd import cmd_build
+
+    captured_argv = []
+
+    def fake_run(argv, *args, **kwargs):
+        captured_argv.append(list(argv))
+        if argv[:2] == ["docker", "info"]:
+            return _make_completed(0)
+        return _make_completed(0)
+
+    with patch("eab.cli.build_cmd.subprocess.run", side_effect=fake_run):
+        rc = cmd_build(
+            target="esp32s3",
+            idf_version="v5.4.1",
+            project_dir="/tmp/proj",
+            no_pull=True,
+            json_mode=False,
+        )
+
+    assert rc == 0
+    build_argv = captured_argv[1]
+    assert "--pull=never" in build_argv
+    assert "IDF_TARGET=esp32s3" in build_argv
+
+
+def test_cmd_build_exit_code_passthrough():
+    from eab.cli.build_cmd import cmd_build
+
+    def fake_run(argv, *args, **kwargs):
+        if argv[:2] == ["docker", "info"]:
+            return _make_completed(0)
+        return _make_completed(2)
+
+    with patch("eab.cli.build_cmd.subprocess.run", side_effect=fake_run):
+        rc = cmd_build(
+            target="esp32c6",
+            idf_version="v5.4.1",
+            project_dir="/tmp/proj",
+            no_pull=False,
+            json_mode=False,
+        )
+
+    assert rc == 2

--- a/eab/tests/test_daemon_regex_fix.py
+++ b/eab/tests/test_daemon_regex_fix.py
@@ -1,0 +1,64 @@
+r"""Regression test for Feature 4 — issue #182.
+
+The _resolve_port tiebreaker regex was accidentally escaped as r"(\\d+)$"
+(literal backslash + digits) instead of r"(\d+)$" (trailing digits). This
+caused unique-device selection to always fall back to the first candidate
+because no port name actually contains a literal backslash.
+
+We exercise the score() lambda by importing the regex pattern directly from
+the source and asserting it matches trailing-digit strings. A deeper
+end-to-end fix would instantiate a SerialDaemon and monkey-patch list_ports;
+that's unnecessary since the bug is purely a one-character regex error.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+DAEMON_SRC = Path(__file__).resolve().parents[1] / "daemon.py"
+
+
+def test_daemon_regex_is_not_double_escaped():
+    text = DAEMON_SRC.read_text()
+    # The broken form must no longer appear in source.
+    assert r'r"(\\d+)$"' not in text
+    # The fixed form must appear.
+    assert r'r"(\d+)$"' in text
+
+
+def test_fixed_regex_matches_trailing_digits():
+    """The fixed pattern correctly scores candidate ports by trailing digits."""
+    pattern = re.compile(r"(\d+)$")
+
+    # Devices that _resolve_port has to tiebreak.
+    m0 = pattern.search("/dev/cu.usbmodem14101")
+    m1 = pattern.search("/dev/cu.usbmodem14102")
+    m_none = pattern.search("/dev/cu.Bluetooth-Incoming-Port")
+
+    assert m0 is not None
+    assert m1 is not None
+    assert int(m0.group(1)) == 14101
+    assert int(m1.group(1)) == 14102
+    assert m_none is None
+
+    # Simulate the scoring tie-break: higher trailing number wins.
+    def score(dev):
+        m = pattern.search(dev)
+        return (int(m.group(1)) if m else -1, dev)
+
+    candidates = [
+        "/dev/cu.usbmodem14101",
+        "/dev/cu.usbmodem14103",
+        "/dev/cu.usbmodem14102",
+    ]
+    assert max(candidates, key=score) == "/dev/cu.usbmodem14103"
+
+
+def test_broken_regex_would_never_match():
+    """Sanity check: confirm the old pattern never matched real port names."""
+    broken = re.compile(r"(\\d+)$")
+    # No real port path ends in a literal backslash + digits.
+    assert broken.search("/dev/cu.usbmodem14101") is None
+    assert broken.search("/dev/ttyUSB0") is None

--- a/eab/tests/test_serial_flock.py
+++ b/eab/tests/test_serial_flock.py
@@ -1,0 +1,93 @@
+"""Unit tests for Feature 1 — device-node ``fcntl.flock`` in ``RealSerialPort``.
+
+All hardware access is mocked. These tests MUST NOT open a real serial port.
+They verify:
+
+1. Successful open calls ``fcntl.flock(fd, LOCK_EX | LOCK_NB)``.
+2. EAGAIN from flock closes the serial object, returns False, and sets
+   ``get_last_flock_status() == "port-locked-by-other"``.
+3. close() releases the flock (LOCK_UN).
+"""
+
+from __future__ import annotations
+
+import errno
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def fake_serial():
+    """Patch ``serial.Serial`` in ``eab.implementations`` with a fake object."""
+    fake_obj = MagicMock()
+    fake_obj.fileno.return_value = 42
+    fake_obj.is_open = True
+    with patch("eab.implementations.serial.Serial", return_value=fake_obj) as ctor:
+        yield ctor, fake_obj
+
+
+def test_flock_acquired_with_lock_ex_lock_nb(fake_serial):
+    """On successful open, fcntl.flock is called with LOCK_EX | LOCK_NB."""
+    from eab.implementations import RealSerialPort
+    import eab.implementations as impls
+
+    _, fake_obj = fake_serial
+    with patch.object(impls, "fcntl") as mock_fcntl, \
+         patch.object(impls, "_HAS_FCNTL", True):
+        mock_fcntl.LOCK_EX = 2
+        mock_fcntl.LOCK_NB = 4
+        mock_fcntl.LOCK_UN = 8
+        mock_fcntl.flock.return_value = None
+
+        port = RealSerialPort()
+        ok = port.open("/dev/cu.usbmodem_fake", 115200)
+
+        assert ok is True, "open should succeed when flock returns"
+        mock_fcntl.flock.assert_called_once_with(42, 2 | 4)
+        assert impls.get_last_flock_status() is None
+
+
+def test_flock_failure_sets_port_locked_status(fake_serial):
+    """EAGAIN from flock closes serial, returns False, status sentinel set."""
+    from eab.implementations import RealSerialPort, get_last_flock_status
+    import eab.implementations as impls
+
+    _, fake_obj = fake_serial
+    with patch.object(impls, "fcntl") as mock_fcntl, \
+         patch.object(impls, "_HAS_FCNTL", True):
+        mock_fcntl.LOCK_EX = 2
+        mock_fcntl.LOCK_NB = 4
+        err = OSError(errno.EAGAIN, "Resource temporarily unavailable")
+        mock_fcntl.flock.side_effect = err
+
+        port = RealSerialPort()
+        ok = port.open("/dev/cu.usbmodem_fake", 115200)
+
+        assert ok is False
+        fake_obj.close.assert_called_once()
+        assert get_last_flock_status() == "port-locked-by-other"
+
+
+def test_close_releases_flock(fake_serial):
+    """close() should call flock(LOCK_UN) before closing the serial handle."""
+    from eab.implementations import RealSerialPort
+    import eab.implementations as impls
+
+    _, fake_obj = fake_serial
+    with patch.object(impls, "fcntl") as mock_fcntl, \
+         patch.object(impls, "_HAS_FCNTL", True):
+        mock_fcntl.LOCK_EX = 2
+        mock_fcntl.LOCK_NB = 4
+        mock_fcntl.LOCK_UN = 8
+        mock_fcntl.flock.return_value = None
+
+        port = RealSerialPort()
+        assert port.open("/dev/cu.usbmodem_fake", 115200) is True
+
+        # Reset to distinguish open-time flock from close-time unlock.
+        mock_fcntl.flock.reset_mock()
+        port.close()
+
+        mock_fcntl.flock.assert_called_once_with(42, 8)
+        fake_obj.close.assert_called_once()


### PR DESCRIPTION
## Summary

Four independent enhancements bundled for the Mac Studio autonomous worker pipeline. All designed to fail safely and mock cleanly — no hardware is exercised by this branch's tests.

### 1. Device-node ``fcntl.flock`` in ``RealSerialPort``
Non-blocking ``LOCK_EX | LOCK_NB`` acquired on the pyserial fd immediately after open; held for the session lifetime; released on ``close()`` (and thus on ``eabctl pause``). Complements the existing file-based ``PortLock`` — the file lock only arbitrates between EAB daemons, whereas this fd-level flock catches ``esptool``, ``screen``, ``pio device monitor``, and any other non-EAB owner of the tty. On ``EAGAIN`` the serial object is closed, ``open()`` returns ``False``, and ``get_last_flock_status()`` returns ``"port-locked-by-other"``. The daemon writes a ``port_flock.status`` sentinel into the session directory, which ``eabctl devices --json`` reads and surfaces as ``status: "port-locked-by-other"``.

### 2. ``eabctl build`` — Docker-wrapped ``idf.py build``
New subcommand: ``eabctl build --target <chip> [--idf-version <ver>] [--project-dir <dir>] [--no-pull]``. Constructs

    docker run --rm -v <proj>:/project -w /project -e IDF_TARGET=<chip> [--pull=never] espressif/idf:<ver> idf.py build

Preflight ``docker info`` check emits an actionable error pointing to ``colima start`` (Mac Studio) or ``sudo systemctl start docker`` (Linux). Exit code is passed through from ``docker run``. Decoupled from the running daemon — flashing still belongs exclusively to ``eabctl flash``.

### 3. ``auto_detect.py`` Linux compat
New ``list_device_nodes()`` returns ``/dev/ttyUSB*``, ``/dev/ttyACM*``, ``/dev/tty.usbmodem*``, ``/dev/tty.usbserial*``, ``/dev/cu.usbmodem*``, ``/dev/cu.usbserial*``. ``detect_boards_pyserial`` surfaces unclaimed nodes as ``Unknown USB serial`` while preserving VID/PID-resolved entries from ``KNOWN_BOARDS`` as the source of truth.

### 4. ``daemon.py:324`` regex fix (#182)
``r"(\\d+)$"`` → ``r"(\d+)$"``. The original pattern matched a literal backslash before the digits so the multi-candidate port tiebreaker never selected the largest trailing number.

## Portability

| Surface             | macOS (MBP / Mac Studio) | Linux (Mac Studio runners, CI) | WSL                      | Native Windows         |
|---------------------|--------------------------|--------------------------------|--------------------------|------------------------|
| ``fcntl.flock``     | Supported                | Supported                      | Supported                | Skipped (no-op)        |
| Device-node globs   | ``/dev/cu.*``, ``tty.*``| ``/dev/ttyUSB*``, ``ttyACM*`` | ``/dev/ttyS*``/ttyUSB*   | ``COM*`` (pyserial only) |
| ``docker info``     | Colima / Docker Desktop  | ``systemctl start docker``    | Docker Desktop + WSL     | Docker Desktop         |
| Regex tie-break     | Yes                      | Yes                            | Yes                      | Yes                    |

## Tests

21 new mocked unit tests — every one patches ``subprocess.run`` / ``fcntl.flock`` / ``glob.glob`` / ``serial.Serial`` — zero real hardware, zero real ``docker run``:

- ``test_serial_flock.py`` — 3 tests (flock called with ``LOCK_EX|LOCK_NB``; EAGAIN path sets status; close releases)
- ``test_build_cmd.py`` — 10 tests (argv construction, parametrized target, preflight success/failure/FileNotFound, ``--no-pull`` propagation, exit-code pass-through)
- ``test_auto_detect_linux.py`` — 5 tests (Linux nodes, macOS nodes, dedup, VID/PID preserved, unclaimed surfaced as unknown)
- ``test_daemon_regex_fix.py`` — 3 tests (broken form absent, fixed form matches trailing digits, broken pattern never matched)

## Related

- Closes #182 (regex tie-break regression)

## Test plan

- [ ] CI runs full suite on Linux (`pytest eab/tests/ -m "not hardware and not integration"`)
- [ ] Manual: ``eabctl build --target esp32c6`` on a Mac Studio with Colima up
- [ ] Manual: ``eabctl devices --json`` while ``screen /dev/cu.usbmodem_x 115200`` holds the port → expect ``status: "port-locked-by-other"``
- [ ] Manual: ``eab/auto_detect.py --json`` on a Linux box with ``/dev/ttyUSB0`` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)